### PR TITLE
Fix workspace detail screen to show header instantly

### DIFF
--- a/mobile/src/screens/WorkspaceDetailScreen.tsx
+++ b/mobile/src/screens/WorkspaceDetailScreen.tsx
@@ -153,14 +153,6 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
     return result
   }, [groupedSessions])
 
-  if (workspaceLoading && !isHost) {
-    return (
-      <View style={[styles.container, styles.center]}>
-        <ActivityIndicator size="large" color="#0a84ff" />
-      </View>
-    )
-  }
-
   const displayName = isHost
     ? (hostInfo ? `${hostInfo.username}@${hostInfo.hostname}` : 'Host Machine')
     : name
@@ -275,7 +267,11 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
         </View>
       )}
 
-      {!isRunning && !isHost ? (
+      {workspaceLoading && !isHost ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color="#0a84ff" />
+        </View>
+      ) : !isRunning && !isHost ? (
         isCreating ? (
           <View style={styles.notRunning}>
             <ActivityIndicator size="large" color="#ff9f0a" style={{ marginBottom: 16 }} />


### PR DESCRIPTION
## Summary
- Move loading state from full-screen to content area only
- Navigation header and action bar now render immediately
- Loading spinner only shows in the sessions content area while data loads

## Test plan
- [ ] Open a workspace from the home screen
- [ ] Verify header appears instantly with back button, title, and settings icon
- [ ] Verify loading spinner shows in content area (not full screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)