### PR TITLE
Rename local image from workspace:latest to perry:latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,7 @@ jobs:
         with:
           context: ./perry
           load: true
-          tags: workspace:latest
+          tags: perry:latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-test
           cache-to: ${{ steps.docker-changes.outputs.changed == 'true' && format('type=registry,ref={0}/{1}:buildcache-test,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -36,7 +36,7 @@ Common issues and their solutions when working with Perry.
    docker ps
    ```
 
-### "Image 'workspace:latest' not found"
+### "Image 'perry:latest' not found"
 
 **Symptoms:** Workspace creation fails with missing image error.
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,7 +3,7 @@ export const DEFAULT_AGENT_PORT = 7391;
 export const SSH_PORT_RANGE_START = 2200;
 export const SSH_PORT_RANGE_END = 2400;
 
-export const WORKSPACE_IMAGE_LOCAL = 'workspace:latest';
+export const WORKSPACE_IMAGE_LOCAL = 'perry:latest';
 export const WORKSPACE_IMAGE_REGISTRY = 'ghcr.io/gricha/perry';
 
 export const VOLUME_PREFIX = 'workspace-';

--- a/test/setup/global.js
+++ b/test/setup/global.js
@@ -29,7 +29,7 @@ async function cleanupOrphanedResources() {
 
 function imageExists() {
   try {
-    execSync('docker image inspect workspace:latest', { stdio: 'ignore' });
+    execSync('docker image inspect perry:latest', { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -38,12 +38,12 @@ function imageExists() {
 
 async function buildImage() {
   if (process.env.SKIP_DOCKER_BUILD === 'true' && imageExists()) {
-    console.log('\n✅ Using existing workspace:latest image (SKIP_DOCKER_BUILD=true)\n');
+    console.log('\n✅ Using existing perry:latest image (SKIP_DOCKER_BUILD=true)\n');
     return;
   }
 
   if (imageExists() && !process.env.FORCE_DOCKER_BUILD) {
-    console.log('\n✅ Using existing workspace:latest image\n');
+    console.log('\n✅ Using existing perry:latest image\n');
     return;
   }
 
@@ -51,7 +51,7 @@ async function buildImage() {
     console.log('\n🏗️  Building workspace Docker image once for all tests...\n');
 
     const buildContext = path.join(process.cwd(), 'perry');
-    const proc = spawn('docker', ['build', '-t', 'workspace:latest', buildContext], {
+    const proc = spawn('docker', ['build', '-t', 'perry:latest', buildContext], {
       stdio: 'inherit',
     });
 


### PR DESCRIPTION
## Summary
- Rename local Docker image from `workspace:latest` to `perry:latest`
- Updates constants, test setup, CI workflow, and documentation
- Standardizes naming to match registry image (`ghcr.io/gricha/perry`)

## Test plan
- [ ] Verify `bun run validate` passes
- [ ] Test `perry build` creates `perry:latest` image
- [ ] Test workspace creation uses new image name

🤖 Generated with [Claude Code](https://claude.com/claude-code)