### PR TITLE
Add theme selector to mobile app

### DIFF
--- a/mobile/src/contexts/ThemeContext.tsx
+++ b/mobile/src/contexts/ThemeContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { ThemeId, ThemeColors, themeColors, themeDefinitions } from '../lib/themes'
+
+const STORAGE_KEY = 'perry_theme'
+
+interface ThemeContextValue {
+  themeId: ThemeId
+  colors: ThemeColors
+  setTheme: (id: ThemeId) => void
+  definitions: typeof themeDefinitions
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [themeId, setThemeId] = useState<ThemeId>('default')
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((stored) => {
+      if (stored && stored in themeColors) {
+        setThemeId(stored as ThemeId)
+      }
+      setIsLoaded(true)
+    })
+  }, [])
+
+  const setTheme = useCallback((id: ThemeId) => {
+    setThemeId(id)
+    AsyncStorage.setItem(STORAGE_KEY, id)
+  }, [])
+
+  const colors = themeColors[themeId]
+
+  if (!isLoaded) {
+    return null
+  }
+
+  return (
+    <ThemeContext.Provider value={{ themeId, colors, setTheme, definitions: themeDefinitions }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/mobile/src/lib/themes.ts
+++ b/mobile/src/lib/themes.ts
@@ -1,0 +1,175 @@
+export type ThemeId = 'default' | 'obsidian' | 'concrete' | 'phosphor' | 'blossom' | 'ember' | 'slate'
+
+export interface ThemePreview {
+  bg: string
+  fg: string
+  accent: string
+}
+
+export interface ThemeDefinition {
+  id: ThemeId
+  name: string
+  description: string
+  preview: ThemePreview
+}
+
+export interface ThemeColors {
+  background: string
+  surface: string
+  surfaceSecondary: string
+  text: string
+  textSecondary: string
+  textMuted: string
+  accent: string
+  accentText: string
+  border: string
+  success: string
+  error: string
+  warning: string
+}
+
+export const themeDefinitions: ThemeDefinition[] = [
+  {
+    id: 'default',
+    name: 'Command',
+    description: 'Deep slate with cyan accents',
+    preview: { bg: '#0f1318', fg: '#e8ecf0', accent: '#22c5d6' },
+  },
+  {
+    id: 'obsidian',
+    name: 'Obsidian',
+    description: 'Purple/violet dark theme',
+    preview: { bg: '#0d0a14', fg: '#ebe9ed', accent: '#a855f7' },
+  },
+  {
+    id: 'concrete',
+    name: 'Concrete',
+    description: 'Brutalist light with sharp edges',
+    preview: { bg: '#f5f5f5', fg: '#141414', accent: '#141414' },
+  },
+  {
+    id: 'phosphor',
+    name: 'Phosphor',
+    description: 'Terminal hacker green on black',
+    preview: { bg: '#080d08', fg: '#80ff80', accent: '#00ff00' },
+  },
+  {
+    id: 'blossom',
+    name: 'Blossom',
+    description: 'Soft pastel pink/rose',
+    preview: { bg: '#fdf6f7', fg: '#3d2c2f', accent: '#ec4899' },
+  },
+  {
+    id: 'ember',
+    name: 'Ember',
+    description: 'Warm cozy with orange/amber',
+    preview: { bg: '#151110', fg: '#efe5db', accent: '#f97316' },
+  },
+  {
+    id: 'slate',
+    name: 'Slate',
+    description: 'Corporate minimal light',
+    preview: { bg: '#f8fafc', fg: '#1e293b', accent: '#3b82f6' },
+  },
+]
+
+export const themeColors: Record<ThemeId, ThemeColors> = {
+  default: {
+    background: '#000000',
+    surface: '#1c1c1e',
+    surfaceSecondary: '#2c2c2e',
+    text: '#ffffff',
+    textSecondary: '#e8ecf0',
+    textMuted: '#8e8e93',
+    accent: '#22c5d6',
+    accentText: '#ffffff',
+    border: '#1c1c1e',
+    success: '#34c759',
+    error: '#ff3b30',
+    warning: '#ff9f0a',
+  },
+  obsidian: {
+    background: '#0d0a14',
+    surface: '#1a1425',
+    surfaceSecondary: '#261e35',
+    text: '#ebe9ed',
+    textSecondary: '#c9c5d0',
+    textMuted: '#8b8693',
+    accent: '#a855f7',
+    accentText: '#ffffff',
+    border: '#2d2640',
+    success: '#34c759',
+    error: '#ff3b30',
+    warning: '#ff9f0a',
+  },
+  concrete: {
+    background: '#f5f5f5',
+    surface: '#ffffff',
+    surfaceSecondary: '#e5e5e5',
+    text: '#141414',
+    textSecondary: '#333333',
+    textMuted: '#666666',
+    accent: '#141414',
+    accentText: '#ffffff',
+    border: '#d4d4d4',
+    success: '#22c55e',
+    error: '#dc2626',
+    warning: '#f59e0b',
+  },
+  phosphor: {
+    background: '#080d08',
+    surface: '#0f170f',
+    surfaceSecondary: '#162016',
+    text: '#80ff80',
+    textSecondary: '#60cc60',
+    textMuted: '#408040',
+    accent: '#00ff00',
+    accentText: '#000000',
+    border: '#1a2a1a',
+    success: '#00ff00',
+    error: '#ff4040',
+    warning: '#ffff00',
+  },
+  blossom: {
+    background: '#fdf6f7',
+    surface: '#ffffff',
+    surfaceSecondary: '#fce7ea',
+    text: '#3d2c2f',
+    textSecondary: '#5c4448',
+    textMuted: '#9c7a80',
+    accent: '#ec4899',
+    accentText: '#ffffff',
+    border: '#f5d0d8',
+    success: '#22c55e',
+    error: '#e11d48',
+    warning: '#f59e0b',
+  },
+  ember: {
+    background: '#151110',
+    surface: '#1f1a18',
+    surfaceSecondary: '#2a2320',
+    text: '#efe5db',
+    textSecondary: '#d4c8bb',
+    textMuted: '#8a7f72',
+    accent: '#f97316',
+    accentText: '#ffffff',
+    border: '#352d28',
+    success: '#22c55e',
+    error: '#ef4444',
+    warning: '#fbbf24',
+  },
+  slate: {
+    background: '#f8fafc',
+    surface: '#ffffff',
+    surfaceSecondary: '#f1f5f9',
+    text: '#1e293b',
+    textSecondary: '#334155',
+    textMuted: '#64748b',
+    accent: '#3b82f6',
+    accentText: '#ffffff',
+    border: '#e2e8f0',
+    success: '#22c55e',
+    error: '#ef4444',
+    warning: '#f59e0b',
+  },
+}

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import { useNavigation } from '@react-navigation/native'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api, WorkspaceInfo, HOST_WORKSPACE_NAME, CreateWorkspaceRequest } from '../lib/api'
 import { useNetwork, parseNetworkError } from '../lib/network'
+import { useTheme } from '../contexts/ThemeContext'
 
 function StatusDot({ status }: { status: WorkspaceInfo['status'] | 'host' }) {
   const colors = {
@@ -37,21 +38,23 @@ function WorkspaceRow({
   workspace: WorkspaceInfo
   onPress: () => void
 }) {
+  const { colors } = useTheme()
   return (
     <TouchableOpacity style={styles.row} onPress={onPress} testID={`workspace-item-${workspace.name}`}>
       <StatusDot status={workspace.status} />
       <View style={styles.rowContent}>
-        <Text style={styles.rowName} testID="workspace-name">{workspace.name}</Text>
+        <Text style={[styles.rowName, { color: colors.text }]} testID="workspace-name">{workspace.name}</Text>
         {workspace.repo && (
-          <Text style={styles.rowRepo} numberOfLines={1}>{workspace.repo}</Text>
+          <Text style={[styles.rowRepo, { color: colors.textMuted }]} numberOfLines={1}>{workspace.repo}</Text>
         )}
       </View>
-      <Text style={styles.rowChevron}>›</Text>
+      <Text style={[styles.rowChevron, { color: colors.textMuted }]}>›</Text>
     </TouchableOpacity>
   )
 }
 
 function HostSection({ onHostPress }: { onHostPress: () => void }) {
+  const { colors } = useTheme()
   const { data: hostInfo, isLoading } = useQuery({
     queryKey: ['hostInfo'],
     queryFn: api.getHostInfo,
@@ -64,30 +67,30 @@ function HostSection({ onHostPress }: { onHostPress: () => void }) {
 
   if (isLoading) {
     return (
-      <View style={styles.hostSection}>
-        <ActivityIndicator size="small" color="#8e8e93" />
+      <View style={[styles.hostSection, { borderBottomColor: colors.border }]}>
+        <ActivityIndicator size="small" color={colors.textMuted} />
       </View>
     )
   }
 
   return (
-    <View style={styles.hostSection}>
+    <View style={[styles.hostSection, { borderBottomColor: colors.border }]}>
       <View style={styles.hostHeader}>
-        <Text style={styles.hostLabel}>Host Machine</Text>
-        <Text style={styles.hostName}>{info?.hostname || hostInfo?.hostname || 'Unknown'}</Text>
+        <Text style={[styles.hostLabel, { color: colors.textMuted }]}>Host Machine</Text>
+        <Text style={[styles.hostName, { color: colors.text }]}>{info?.hostname || hostInfo?.hostname || 'Unknown'}</Text>
       </View>
 
       {hostInfo?.enabled ? (
         <>
-          <TouchableOpacity style={styles.hostRow} onPress={onHostPress}>
+          <TouchableOpacity style={[styles.hostRow, { backgroundColor: colors.surface }]} onPress={onHostPress}>
             <StatusDot status="host" />
             <View style={styles.rowContent}>
               <Text style={styles.hostRowName}>
                 {hostInfo.username}@{hostInfo.hostname}
               </Text>
-              <Text style={styles.hostRowPath}>{hostInfo.homeDir}</Text>
+              <Text style={[styles.hostRowPath, { color: colors.textMuted }]}>{hostInfo.homeDir}</Text>
             </View>
-            <Text style={styles.rowChevron}>›</Text>
+            <Text style={[styles.rowChevron, { color: colors.textMuted }]}>›</Text>
           </TouchableOpacity>
           <Text style={styles.hostWarning}>
             Commands run directly on your machine without isolation
@@ -96,9 +99,9 @@ function HostSection({ onHostPress }: { onHostPress: () => void }) {
       ) : (
         info && (
           <View style={styles.hostStats}>
-            <Text style={styles.hostStat}>{info.workspacesCount} workspaces</Text>
-            <Text style={styles.hostStatDivider}>•</Text>
-            <Text style={styles.hostStat}>Docker {info.dockerVersion}</Text>
+            <Text style={[styles.hostStat, { color: colors.textMuted }]}>{info.workspacesCount} workspaces</Text>
+            <Text style={[styles.hostStatDivider, { color: colors.textMuted }]}>•</Text>
+            <Text style={[styles.hostStat, { color: colors.textMuted }]}>Docker {info.dockerVersion}</Text>
           </View>
         )
       )}
@@ -111,6 +114,7 @@ export function HomeScreen() {
   const navigation = useNavigation<any>()
   const queryClient = useQueryClient()
   const { status } = useNetwork()
+  const { colors } = useTheme()
   const [showCreate, setShowCreate] = useState(false)
   const [newName, setNewName] = useState('')
   const [newRepo, setNewRepo] = useState('')
@@ -156,20 +160,20 @@ export function HomeScreen() {
 
   if (isLoading) {
     return (
-      <View style={[styles.container, styles.center, { paddingTop: insets.top }]}>
-        <ActivityIndicator size="large" color="#0a84ff" />
+      <View style={[styles.container, styles.center, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.accent} />
       </View>
     )
   }
 
   if (error && status !== 'connected') {
     return (
-      <View style={[styles.container, styles.center, { paddingTop: insets.top }]}>
-        <Text style={styles.errorIcon}>!</Text>
-        <Text style={styles.errorTitle}>Cannot Load Workspaces</Text>
-        <Text style={styles.errorText}>{parseNetworkError(error)}</Text>
-        <TouchableOpacity style={styles.retryBtn} onPress={() => refetch()}>
-          <Text style={styles.retryBtnText}>Retry</Text>
+      <View style={[styles.container, styles.center, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+        <Text style={[styles.errorIcon, { color: colors.error }]}>!</Text>
+        <Text style={[styles.errorTitle, { color: colors.text }]}>Cannot Load Workspaces</Text>
+        <Text style={[styles.errorText, { color: colors.textMuted }]}>{parseNetworkError(error)}</Text>
+        <TouchableOpacity style={[styles.retryBtn, { backgroundColor: colors.accent }]} onPress={() => refetch()}>
+          <Text style={[styles.retryBtnText, { color: colors.accentText }]}>Retry</Text>
         </TouchableOpacity>
       </View>
     )
@@ -182,23 +186,23 @@ export function HomeScreen() {
   })
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
-      <View style={styles.header}>
-        <Text style={styles.headerTitle}>Perry</Text>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Perry</Text>
         <View style={styles.headerButtons}>
           <TouchableOpacity
             style={styles.headerBtn}
             onPress={() => setShowCreate(true)}
             testID="add-workspace-button"
           >
-            <Text style={styles.addIcon}>+</Text>
+            <Text style={[styles.addIcon, { color: colors.accent }]}>+</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.headerBtn}
             onPress={() => navigation.navigate('Settings')}
             testID="settings-button"
           >
-            <Text style={styles.settingsIcon}>⚙</Text>
+            <Text style={[styles.settingsIcon, { color: colors.textMuted }]}>⚙</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -213,15 +217,15 @@ export function HomeScreen() {
             onPress={() => handleWorkspacePress(item)}
           />
         )}
-        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor="#0a84ff" />}
+        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={colors.accent} />}
         contentContainerStyle={[styles.list, { paddingBottom: insets.bottom + 20 }]}
         ListEmptyComponent={
           <View style={styles.empty}>
-            <Text style={styles.emptyText}>No workspaces</Text>
-            <Text style={styles.emptySubtext}>Create one from the web UI or CLI</Text>
+            <Text style={[styles.emptyText, { color: colors.textMuted }]}>No workspaces</Text>
+            <Text style={[styles.emptySubtext, { color: colors.textMuted }]}>Create one from the web UI or CLI</Text>
           </View>
         }
-        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        ItemSeparatorComponent={() => <View style={[styles.separator, { backgroundColor: colors.border }]} />}
       />
 
       <Modal
@@ -231,23 +235,23 @@ export function HomeScreen() {
         onRequestClose={() => setShowCreate(false)}
       >
         <KeyboardAvoidingView
-          style={styles.modalContainer}
+          style={[styles.modalContainer, { backgroundColor: colors.background }]}
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         >
-          <View style={styles.modalHeader}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.border }]}>
             <TouchableOpacity onPress={() => setShowCreate(false)} style={styles.modalCancelBtn}>
-              <Text style={styles.modalCancelText}>Cancel</Text>
+              <Text style={[styles.modalCancelText, { color: colors.accent }]}>Cancel</Text>
             </TouchableOpacity>
-            <Text style={styles.modalTitle}>New Workspace</Text>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>New Workspace</Text>
             <TouchableOpacity
               onPress={handleCreate}
               style={styles.modalCreateBtn}
               disabled={createMutation.isPending || !newName.trim()}
             >
               {createMutation.isPending ? (
-                <ActivityIndicator size="small" color="#0a84ff" />
+                <ActivityIndicator size="small" color={colors.accent} />
               ) : (
-                <Text style={[styles.modalCreateText, !newName.trim() && styles.modalCreateTextDisabled]}>
+                <Text style={[styles.modalCreateText, { color: colors.accent }, !newName.trim() && { color: colors.textMuted }]}>
                   Create
                 </Text>
               )}
@@ -255,26 +259,26 @@ export function HomeScreen() {
           </View>
           <View style={styles.modalContent}>
             <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Name</Text>
+              <Text style={[styles.inputLabel, { color: colors.textMuted }]}>Name</Text>
               <TextInput
-                style={styles.modalInput}
+                style={[styles.modalInput, { backgroundColor: colors.surface, color: colors.text }]}
                 value={newName}
                 onChangeText={setNewName}
                 placeholder="my-project"
-                placeholderTextColor="#636366"
+                placeholderTextColor={colors.textMuted}
                 autoCapitalize="none"
                 autoCorrect={false}
                 autoFocus
               />
             </View>
             <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Repository (optional)</Text>
+              <Text style={[styles.inputLabel, { color: colors.textMuted }]}>Repository (optional)</Text>
               <TextInput
-                style={styles.modalInput}
+                style={[styles.modalInput, { backgroundColor: colors.surface, color: colors.text }]}
                 value={newRepo}
                 onChangeText={setNewRepo}
                 placeholder="https://github.com/user/repo"
-                placeholderTextColor="#636366"
+                placeholderTextColor={colors.textMuted}
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"


### PR DESCRIPTION
## Summary
- Add 7 themes matching web app (Command, Obsidian, Concrete, Phosphor, Blossom, Ember, Slate)
- Create ThemeContext with AsyncStorage persistence for theme selection
- Add visual theme picker UI in Settings with color grid preview
- Apply theme colors throughout Home screen, Settings screen, and navigation
- StatusBar automatically adapts between light/dark based on selected theme

## Test plan
- [ ] Open Settings and verify theme picker appears under "Appearance"
- [ ] Tap theme swatches and verify UI colors change immediately
- [ ] Close and reopen app to verify theme persists
- [ ] Test light themes (Concrete, Blossom, Slate) have dark status bar
- [ ] Test dark themes have light status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)