### PR TITLE
Add clone parameter support to startWorkspace in web and mobile clients

### DIFF
--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -151,7 +151,7 @@ function createClient() {
       get: (input: { name: string }) => Promise<WorkspaceInfo>
       create: (input: CreateWorkspaceRequest) => Promise<WorkspaceInfo>
       delete: (input: { name: string }) => Promise<{ success: boolean }>
-      start: (input: { name: string }) => Promise<WorkspaceInfo>
+      start: (input: { name: string; clone?: string; env?: Record<string, string> }) => Promise<WorkspaceInfo>
       stop: (input: { name: string }) => Promise<WorkspaceInfo>
       logs: (input: { name: string; tail?: number }) => Promise<string>
       sync: (input: { name: string }) => Promise<{ success: boolean }>
@@ -230,7 +230,8 @@ export const api = {
   getWorkspace: (name: string) => client.workspaces.get({ name }),
   createWorkspace: (data: CreateWorkspaceRequest) => client.workspaces.create(data),
   deleteWorkspace: (name: string) => client.workspaces.delete({ name }),
-  startWorkspace: (name: string) => client.workspaces.start({ name }),
+  startWorkspace: (name: string, options?: { clone?: string; env?: Record<string, string> }) =>
+    client.workspaces.start({ name, clone: options?.clone, env: options?.env }),
   stopWorkspace: (name: string) => client.workspaces.stop({ name }),
   getLogs: (name: string, tail = 100) => client.workspaces.logs({ name, tail }),
   syncWorkspace: (name: string) => client.workspaces.sync({ name }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -53,7 +53,7 @@ const client = createORPCClient<{
     get: (input: { name: string }) => Promise<WorkspaceInfo>
     create: (input: CreateWorkspaceRequest) => Promise<WorkspaceInfo>
     delete: (input: { name: string }) => Promise<{ success: boolean }>
-    start: (input: { name: string }) => Promise<WorkspaceInfo>
+    start: (input: { name: string; clone?: string; env?: Record<string, string> }) => Promise<WorkspaceInfo>
     stop: (input: { name: string }) => Promise<WorkspaceInfo>
     logs: (input: { name: string; tail?: number }) => Promise<string>
     sync: (input: { name: string }) => Promise<{ success: boolean }>
@@ -107,7 +107,8 @@ export const api = {
   getWorkspace: (name: string) => client.workspaces.get({ name }),
   createWorkspace: (data: CreateWorkspaceRequest) => client.workspaces.create(data),
   deleteWorkspace: (name: string) => client.workspaces.delete({ name }),
-  startWorkspace: (name: string) => client.workspaces.start({ name }),
+  startWorkspace: (name: string, options?: { clone?: string; env?: Record<string, string> }) =>
+    client.workspaces.start({ name, clone: options?.clone, env: options?.env }),
   stopWorkspace: (name: string) => client.workspaces.stop({ name }),
   getLogs: (name: string, tail = 100) => client.workspaces.logs({ name, tail }),
   syncWorkspace: (name: string) => client.workspaces.sync({ name }),


### PR DESCRIPTION
## Summary
- Fixed missing `--clone` parameter support in web and mobile API clients for `startWorkspace`
- Updated type definitions to include `clone` and `env` optional parameters
- Aligned web/mobile client behavior with CLI where `perry start --clone <url>` works correctly

## Background
After the consolidation of `perry create` into `perry start` (#7), the CLI correctly supports `perry start myworkspace --clone <url>`. However, the web and mobile API clients had outdated type definitions that didn't include the `clone` parameter, preventing UIs from creating workspaces with repositories.

## Changes
**web/src/lib/api.ts:**
- Updated `start` RPC type to include `clone?: string` and `env?: Record<string, string>`
- Updated `startWorkspace` function signature to accept and forward these options

**mobile/src/lib/api.ts:**
- Same changes as web client for consistency

## Test plan
- [ ] Verify CLI still works: `perry start mytest --clone https://github.com/user/repo`
- [ ] Test web UI can create workspaces with repositories
- [ ] Test mobile app can create workspaces with repositories
- [ ] Verify existing workspaces can still be started without the clone parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)