### PR TITLE
Add Playwright e2e tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,3 +197,100 @@ jobs:
           # Skip Docker build in test setup since we already have the image
           export SKIP_DOCKER_BUILD=true
           bun run test
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            web/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock', '**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: |
+          bun install
+          cd web && bun install
+
+      - name: Install Playwright browsers
+        run: cd web && bun x playwright install chromium --with-deps
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for Dockerfile changes
+        id: docker-changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+
+          if git diff --name-only "$BASE_SHA" HEAD 2>/dev/null | grep -q "^perry/"; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build workspace image (with cache)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./perry
+          load: true
+          tags: perry:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-test
+          cache-to: ${{ steps.docker-changes.outputs.changed == 'true' && format('type=registry,ref={0}/{1}:buildcache-test,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+
+      - name: Start agent
+        run: |
+          bun run src/index.ts agent run --port 7391 &
+          sleep 5
+          curl -s http://localhost:7391/health || (echo "Agent failed to start" && exit 1)
+
+      - name: Create test workspace
+        run: |
+          bun run src/index.ts start test
+          bun run src/index.ts list
+
+      - name: Run Playwright tests
+        run: |
+          cd web && bun run test:e2e --grep-invert "OpenCode"
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds a new `e2e` job to the CI workflow that runs Playwright tests
- Runs in parallel with existing `test` and `binary` jobs (all depend on `build`)
- Sets up the agent, creates a test workspace, and runs the web UI e2e tests
- Excludes OpenCode tests that require API keys (uses `--grep-invert "OpenCode"`)
- Uploads Playwright report as an artifact for debugging

## Test plan
- [x] Verify e2e job runs in parallel with other jobs
- [x] Verify Playwright tests execute against the running agent
- [x] Check Playwright report artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)