### PR TITLE
Fix Docker-in-Docker by adding /var/lib/docker volume

### DIFF
--- a/perry/Dockerfile
+++ b/perry/Dockerfile
@@ -180,6 +180,8 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 
 RUN curl -fsSL https://opencode.ai/install | bash
 
+RUN bunx playwright install chromium --with-deps
+
 USER root
 
 ENV PATH="/home/workspace/.opencode/bin:${PATH}"


### PR DESCRIPTION
## Summary

- Add `/var/lib/docker` volume mount to workspace containers, fixing Docker-in-Docker
- Pre-install Playwright Chromium in workspace image for Perry development

## Problem

DinD was broken because Perry only mounted `/home/workspace` as a volume. Without `/var/lib/docker` on a real volume, nested Docker tries overlay-on-overlay which fails with "invalid argument".

The original [subroutinecom/workspace](https://github.com/subroutinecom/workspace) project mounted three volumes including `/var/lib/docker` - this was missing in Perry.

## Changes

**`src/workspace/manager.ts`**
- Create `workspace-{name}-docker` volume alongside existing home volume  
- Mount to `/var/lib/docker` in container
- Clean up volume on workspace deletion

**`perry/Dockerfile`**
- Add `bunx playwright install chromium --with-deps` for web testing support

## Test plan

- [x] `bun run validate` passes (101 tests + 20 Playwright)
- [x] New workspace has both volumes created
- [x] `docker run --rm hello-world` works inside workspace
- [x] Existing workspaces unaffected (will get docker volume on recreate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)