### PR TITLE
Add web linting to CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Typecheck
         run: bun x tsc --noEmit
 
+      - name: Lint web
+        run: bun run lint:web
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add `bun run lint:web` step to the CI lint job
- Web linting was running locally via `bun run validate` but not enforced in CI
- This closes a gap where web lint errors could slip through

## Test plan
- [x] Local `bun run validate` passes
- [ ] CI lint job runs web linting step

🤖 Generated with [Claude Code](https://claude.com/claude-code)