### PR TITLE
Expand oxlint rules from 7 to 17

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -7,7 +7,18 @@
     "no-var": "error",
     "prefer-const": "error",
     "no-empty": "error",
-    "no-useless-catch": "error"
+    "no-useless-catch": "error",
+    "no-self-compare": "error",
+    "no-constant-condition": "error",
+    "no-unreachable": "error",
+    "no-loss-of-precision": "error",
+    "no-debugger": "error",
+    "no-duplicate-case": "error",
+    "no-fallthrough": "error",
+    "no-unsafe-finally": "error",
+    "no-sparse-arrays": "error",
+    "no-template-curly-in-string": "error",
+    "valid-typeof": "error"
   },
   "ignorePatterns": ["dist", "node_modules", "workspace"]
 }


### PR DESCRIPTION
## Summary
- Expand oxlint configuration from 7 rules to 17 rules
- Add rules that catch common bugs: dead code, numeric precision, switch fallthrough, etc.
- No violations found in current codebase

## New rules added
- `no-self-compare` - catches `x === x` mistakes
- `no-constant-condition` - catches infinite loops
- `no-unreachable` - catches dead code
- `no-loss-of-precision` - catches numeric bugs
- `no-debugger` - catches leftover debuggers
- `no-duplicate-case` - catches switch statement bugs
- `no-fallthrough` - catches missing breaks
- `no-unsafe-finally` - catches finally block issues
- `no-sparse-arrays` - catches array hole bugs
- `no-template-curly-in-string` - catches template literal typos
- `valid-typeof` - catches typeof comparison bugs

## Test plan
- [x] `bun run lint` passes with no violations
- [x] `bun run validate` passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)