### PR TITLE
Consolidate chat handlers with base class pattern

### DIFF
--- a/src/chat/base-claude-session.ts
+++ b/src/chat/base-claude-session.ts
@@ -1,0 +1,206 @@
+import type { ChatProcess, ClaudeStreamMessage, MessageCallback, SpawnConfig } from './types';
+import { DEFAULT_CLAUDE_MODEL } from '../shared/constants';
+
+export abstract class BaseClaudeSession {
+  protected process: ChatProcess | null = null;
+  protected sessionId?: string;
+  protected model: string;
+  protected sessionModel: string;
+  protected onMessage: MessageCallback;
+  protected buffer: string = '';
+
+  constructor(
+    sessionId: string | undefined,
+    model: string | undefined,
+    onMessage: MessageCallback
+  ) {
+    this.sessionId = sessionId;
+    this.model = model || DEFAULT_CLAUDE_MODEL;
+    this.sessionModel = this.model;
+    this.onMessage = onMessage;
+  }
+
+  protected abstract getSpawnConfig(userMessage: string): SpawnConfig;
+  protected abstract getLogPrefix(): string;
+
+  async sendMessage(userMessage: string): Promise<void> {
+    const logPrefix = this.getLogPrefix();
+    const { command, options } = this.getSpawnConfig(userMessage);
+
+    console.log(`[${logPrefix}] Running:`, command.join(' '));
+
+    this.onMessage({
+      type: 'system',
+      content: 'Processing your message...',
+      timestamp: new Date().toISOString(),
+    });
+
+    try {
+      const proc = Bun.spawn(command, {
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        ...options,
+      });
+
+      this.process = proc;
+
+      if (!proc.stdout || !proc.stderr) {
+        throw new Error('Failed to get process streams');
+      }
+
+      console.log(`[${logPrefix}] Process spawned, waiting for output...`);
+
+      const stderrPromise = new Response(proc.stderr).text();
+
+      const decoder = new TextDecoder();
+      let receivedAnyOutput = false;
+
+      for await (const chunk of proc.stdout) {
+        const text = decoder.decode(chunk);
+        console.log(`[${logPrefix}] Received chunk:`, text.length, 'bytes');
+        receivedAnyOutput = true;
+        this.buffer += text;
+        this.processBuffer();
+      }
+
+      const exitCode = await proc.exited;
+      console.log(
+        `[${logPrefix}] Process exited with code:`,
+        exitCode,
+        'receivedOutput:',
+        receivedAnyOutput
+      );
+
+      const stderrText = await stderrPromise;
+      if (stderrText) {
+        console.error(`[${logPrefix}] stderr:`, stderrText);
+      }
+
+      if (exitCode !== 0) {
+        this.onMessage({
+          type: 'error',
+          content: stderrText || `Claude exited with code ${exitCode}`,
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+
+      if (!receivedAnyOutput) {
+        this.onMessage({
+          type: 'error',
+          content: this.getNoOutputErrorMessage(),
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+
+      this.onMessage({
+        type: 'done',
+        content: 'Response complete',
+        timestamp: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.error(`[${logPrefix}] Error:`, err);
+      this.onMessage({
+        type: 'error',
+        content: (err as Error).message,
+        timestamp: new Date().toISOString(),
+      });
+    } finally {
+      this.process = null;
+    }
+  }
+
+  protected getNoOutputErrorMessage(): string {
+    return 'No response from Claude. Check if Claude is authenticated.';
+  }
+
+  protected processBuffer(): void {
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      try {
+        const msg: ClaudeStreamMessage = JSON.parse(line);
+        this.handleStreamMessage(msg);
+      } catch {
+        console.error(`[${this.getLogPrefix()}] Failed to parse:`, line);
+      }
+    }
+  }
+
+  protected handleStreamMessage(msg: ClaudeStreamMessage): void {
+    const timestamp = new Date().toISOString();
+
+    if (msg.type === 'system' && msg.subtype === 'init') {
+      this.sessionId = msg.session_id;
+      this.sessionModel = this.model;
+      this.onMessage({
+        type: 'system',
+        content: `Session started: ${msg.session_id?.slice(0, 8)}...`,
+        timestamp,
+      });
+      return;
+    }
+
+    if (msg.type === 'assistant' && msg.message?.content) {
+      for (const block of msg.message.content) {
+        if (block.type === 'tool_use') {
+          this.onMessage({
+            type: 'tool_use',
+            content: JSON.stringify(block.input, null, 2),
+            toolName: block.name,
+            toolId: block.id,
+            timestamp,
+          });
+        }
+      }
+      return;
+    }
+
+    if (msg.type === 'stream_event' && msg.event?.type === 'content_block_delta') {
+      const delta = msg.event?.delta;
+      if (delta?.type === 'text_delta' && delta?.text) {
+        this.onMessage({
+          type: 'assistant',
+          content: delta.text,
+          timestamp,
+        });
+      }
+      return;
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    if (this.process) {
+      this.process.kill();
+      this.process = null;
+      this.onMessage({
+        type: 'system',
+        content: 'Chat interrupted',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  setModel(model: string): void {
+    if (this.model !== model) {
+      this.model = model;
+      if (this.sessionModel !== model) {
+        this.sessionId = undefined;
+        this.onMessage({
+          type: 'system',
+          content: `Switching to model: ${model}`,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+}

--- a/src/chat/base-opencode-session.ts
+++ b/src/chat/base-opencode-session.ts
@@ -1,0 +1,225 @@
+import type { ChatProcess, OpencodeStreamEvent, MessageCallback, SpawnConfig } from './types';
+
+export abstract class BaseOpencodeSession {
+  protected process: ChatProcess | null = null;
+  protected sessionId?: string;
+  protected model?: string;
+  protected sessionModel?: string;
+  protected onMessage: MessageCallback;
+  protected buffer: string = '';
+  protected historyLoaded: boolean = false;
+
+  constructor(
+    sessionId: string | undefined,
+    model: string | undefined,
+    onMessage: MessageCallback
+  ) {
+    this.sessionId = sessionId;
+    this.model = model;
+    this.sessionModel = model;
+    this.onMessage = onMessage;
+  }
+
+  protected abstract getSpawnConfig(userMessage: string): SpawnConfig;
+  protected abstract getLogPrefix(): string;
+  protected abstract getNoOutputErrorMessage(): string;
+
+  abstract loadHistory(): Promise<void>;
+
+  async sendMessage(userMessage: string): Promise<void> {
+    if (this.sessionId && !this.historyLoaded) {
+      await this.loadHistory();
+    }
+
+    const logPrefix = this.getLogPrefix();
+    const { command, options } = this.getSpawnConfig(userMessage);
+
+    console.log(`[${logPrefix}] Running:`, command.join(' '));
+
+    this.onMessage({
+      type: 'system',
+      content: 'Processing your message...',
+      timestamp: new Date().toISOString(),
+    });
+
+    try {
+      const proc = Bun.spawn(command, {
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        ...options,
+      });
+
+      this.process = proc;
+
+      if (!proc.stdout || !proc.stderr) {
+        throw new Error('Failed to get process streams');
+      }
+
+      console.log(`[${logPrefix}] Process spawned, waiting for output...`);
+
+      const stderrPromise = new Response(proc.stderr).text();
+
+      const decoder = new TextDecoder();
+      let receivedAnyOutput = false;
+
+      for await (const chunk of proc.stdout) {
+        const text = decoder.decode(chunk);
+        console.log(`[${logPrefix}] Received chunk:`, text.length, 'bytes');
+        receivedAnyOutput = true;
+        this.buffer += text;
+        this.processBuffer();
+      }
+
+      const exitCode = await proc.exited;
+      console.log(
+        `[${logPrefix}] Process exited with code:`,
+        exitCode,
+        'receivedOutput:',
+        receivedAnyOutput
+      );
+
+      const stderrText = await stderrPromise;
+      if (stderrText) {
+        console.error(`[${logPrefix}] stderr:`, stderrText);
+      }
+
+      if (exitCode !== 0) {
+        this.onMessage({
+          type: 'error',
+          content: stderrText || `OpenCode exited with code ${exitCode}`,
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+
+      if (!receivedAnyOutput) {
+        this.onMessage({
+          type: 'error',
+          content: this.getNoOutputErrorMessage(),
+          timestamp: new Date().toISOString(),
+        });
+        return;
+      }
+
+      this.onMessage({
+        type: 'done',
+        content: 'Response complete',
+        timestamp: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.error(`[${logPrefix}] Error:`, err);
+      this.onMessage({
+        type: 'error',
+        content: (err as Error).message,
+        timestamp: new Date().toISOString(),
+      });
+    } finally {
+      this.process = null;
+    }
+  }
+
+  protected processBuffer(): void {
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      try {
+        const event: OpencodeStreamEvent = JSON.parse(line);
+        this.handleStreamEvent(event);
+      } catch {
+        console.error(`[${this.getLogPrefix()}] Failed to parse:`, line);
+      }
+    }
+  }
+
+  protected handleStreamEvent(event: OpencodeStreamEvent): void {
+    const timestamp = new Date().toISOString();
+
+    if (event.type === 'step_start' && event.sessionID) {
+      if (!this.sessionId) {
+        this.sessionId = event.sessionID;
+        this.sessionModel = this.model;
+        this.historyLoaded = true;
+        this.onMessage({
+          type: 'system',
+          content: `Session started ${this.sessionId}`,
+          timestamp,
+        });
+      }
+      return;
+    }
+
+    if (event.type === 'text' && event.part?.text) {
+      this.onMessage({
+        type: 'assistant',
+        content: event.part.text,
+        timestamp,
+      });
+      return;
+    }
+
+    if (event.type === 'tool_use' && event.part) {
+      const toolName = event.part.tool || 'unknown';
+      const toolId = event.part.callID || event.part.id;
+      const input = event.part.state?.input;
+      const output = event.part.state?.output;
+      const title =
+        event.part.state?.title || (input as { description?: string })?.description || toolName;
+
+      console.log(`[${this.getLogPrefix()}] Tool use:`, toolName, title);
+
+      this.onMessage({
+        type: 'tool_use',
+        content: JSON.stringify(input, null, 2),
+        toolName: title || toolName,
+        toolId,
+        timestamp,
+      });
+
+      if (output) {
+        this.onMessage({
+          type: 'tool_result',
+          content: output,
+          toolName,
+          toolId,
+          timestamp,
+        });
+      }
+      return;
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    if (this.process) {
+      this.process.kill();
+      this.process = null;
+      this.onMessage({
+        type: 'system',
+        content: 'Chat interrupted',
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  setModel(model: string): void {
+    if (this.model !== model) {
+      this.model = model;
+      if (this.sessionModel !== model) {
+        this.sessionId = undefined;
+        this.historyLoaded = false;
+        this.onMessage({
+          type: 'system',
+          content: `Switching to model: ${model}`,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+}

--- a/src/chat/handler.ts
+++ b/src/chat/handler.ts
@@ -1,65 +1,27 @@
-import type { Subprocess } from 'bun';
+import { BaseClaudeSession } from './base-claude-session';
+import type { ChatMessage, MessageCallback, SpawnConfig, ContainerChatOptions } from './types';
 
-export interface ChatOptions {
-  containerName: string;
-  workDir?: string;
-  sessionId?: string;
-  model?: string;
-}
+export type { ChatMessage };
 
-export interface ChatMessage {
-  type: 'user' | 'assistant' | 'system' | 'tool_use' | 'tool_result' | 'error' | 'done';
-  content: string;
-  timestamp: string;
-  toolName?: string;
-  toolId?: string;
-}
+export interface ChatOptions extends ContainerChatOptions {}
 
-interface StreamMessage {
-  type: string;
-  subtype?: string;
-  session_id?: string;
-  model?: string;
-  message?: {
-    content?: Array<{
-      type: string;
-      text?: string;
-      name?: string;
-      id?: string;
-      input?: unknown;
-    }>;
-  };
-  event?: {
-    type: string;
-    delta?: {
-      type: string;
-      text?: string;
-    };
-  };
-  result?: string;
-}
-
-export class ChatSession {
-  private process: Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+export class ChatSession extends BaseClaudeSession {
   private containerName: string;
   private workDir: string;
-  private sessionId?: string;
-  private model: string;
-  private sessionModel: string;
-  private onMessage: (message: ChatMessage) => void;
-  private buffer: string = '';
 
-  constructor(options: ChatOptions, onMessage: (message: ChatMessage) => void) {
+  constructor(options: ChatOptions, onMessage: MessageCallback) {
+    super(options.sessionId, options.model, onMessage);
     this.containerName = options.containerName;
     this.workDir = options.workDir || '/home/workspace';
-    this.sessionId = options.sessionId;
-    this.model = options.model || 'sonnet';
-    this.sessionModel = this.model;
-    this.onMessage = onMessage;
   }
 
-  async sendMessage(userMessage: string): Promise<void> {
+  protected getLogPrefix(): string {
+    return 'chat';
+  }
+
+  protected getSpawnConfig(userMessage: string): SpawnConfig {
     const args = [
+      'docker',
       'exec',
       '-u',
       'workspace',
@@ -83,176 +45,14 @@ export class ChatSession {
 
     args.push(userMessage);
 
-    console.log('[chat] Running:', 'docker', args.join(' '));
-
-    this.onMessage({
-      type: 'system',
-      content: 'Processing your message...',
-      timestamp: new Date().toISOString(),
-    });
-
-    try {
-      const proc = Bun.spawn(['docker', ...args], {
-        stdin: 'ignore',
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-
-      this.process = proc;
-
-      if (!proc.stdout || !proc.stderr) {
-        throw new Error('Failed to get process streams');
-      }
-
-      console.log('[chat] Process spawned, waiting for output...');
-
-      const stderrPromise = new Response(proc.stderr).text();
-
-      const decoder = new TextDecoder();
-      let receivedAnyOutput = false;
-
-      for await (const chunk of proc.stdout) {
-        const text = decoder.decode(chunk);
-        console.log('[chat] Received chunk:', text.length, 'bytes');
-        receivedAnyOutput = true;
-        this.buffer += text;
-        this.processBuffer();
-      }
-
-      const exitCode = await proc.exited;
-      console.log(
-        '[chat] Process exited with code:',
-        exitCode,
-        'receivedOutput:',
-        receivedAnyOutput
-      );
-
-      const stderrText = await stderrPromise;
-      if (stderrText) {
-        console.error('[chat] stderr:', stderrText);
-      }
-
-      if (exitCode !== 0) {
-        this.onMessage({
-          type: 'error',
-          content: stderrText || `Claude exited with code ${exitCode}`,
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      if (!receivedAnyOutput) {
-        this.onMessage({
-          type: 'error',
-          content: 'No response from Claude. Check if Claude is authenticated in the workspace.',
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      this.onMessage({
-        type: 'done',
-        content: 'Response complete',
-        timestamp: new Date().toISOString(),
-      });
-    } catch (err) {
-      console.error('[chat] Error:', err);
-      this.onMessage({
-        type: 'error',
-        content: (err as Error).message,
-        timestamp: new Date().toISOString(),
-      });
-    } finally {
-      this.process = null;
-    }
+    return {
+      command: args,
+      options: {},
+    };
   }
 
-  private processBuffer(): void {
-    const lines = this.buffer.split('\n');
-    this.buffer = lines.pop() || '';
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      try {
-        const msg: StreamMessage = JSON.parse(line);
-        this.handleStreamMessage(msg);
-      } catch {
-        console.error('[chat] Failed to parse:', line);
-      }
-    }
-  }
-
-  private handleStreamMessage(msg: StreamMessage): void {
-    const timestamp = new Date().toISOString();
-
-    if (msg.type === 'system' && msg.subtype === 'init') {
-      this.sessionId = msg.session_id;
-      this.sessionModel = this.model;
-      this.onMessage({
-        type: 'system',
-        content: `Session started: ${msg.session_id?.slice(0, 8)}...`,
-        timestamp,
-      });
-      return;
-    }
-
-    if (msg.type === 'assistant' && msg.message?.content) {
-      for (const block of msg.message.content) {
-        if (block.type === 'tool_use') {
-          this.onMessage({
-            type: 'tool_use',
-            content: JSON.stringify(block.input, null, 2),
-            toolName: block.name,
-            toolId: block.id,
-            timestamp,
-          });
-        }
-      }
-      return;
-    }
-
-    if (msg.type === 'stream_event' && msg.event?.type === 'content_block_delta') {
-      const delta = msg.event?.delta;
-      if (delta?.type === 'text_delta' && delta?.text) {
-        this.onMessage({
-          type: 'assistant',
-          content: delta.text,
-          timestamp,
-        });
-      }
-      return;
-    }
-  }
-
-  async interrupt(): Promise<void> {
-    if (this.process) {
-      this.process.kill();
-      this.process = null;
-      this.onMessage({
-        type: 'system',
-        content: 'Chat interrupted',
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  setModel(model: string): void {
-    if (this.model !== model) {
-      this.model = model;
-      if (this.sessionModel !== model) {
-        this.sessionId = undefined;
-        this.onMessage({
-          type: 'system',
-          content: `Switching to model: ${model}`,
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  getSessionId(): string | undefined {
-    return this.sessionId;
+  protected override getNoOutputErrorMessage(): string {
+    return 'No response from Claude. Check if Claude is authenticated in the workspace.';
   }
 }
 

--- a/src/chat/host-handler.ts
+++ b/src/chat/host-handler.ts
@@ -1,54 +1,24 @@
-import type { Subprocess } from 'bun';
-import type { ChatMessage } from './handler';
 import { homedir } from 'os';
+import { BaseClaudeSession } from './base-claude-session';
+import type { ChatMessage, MessageCallback, SpawnConfig, HostChatOptions } from './types';
 
-export interface HostChatOptions {
-  workDir?: string;
-  sessionId?: string;
-  model?: string;
-}
+export type { HostChatOptions };
 
-interface StreamMessage {
-  type: string;
-  subtype?: string;
-  session_id?: string;
-  model?: string;
-  message?: {
-    content?: Array<{
-      type: string;
-      text?: string;
-      name?: string;
-      id?: string;
-      input?: unknown;
-    }>;
-  };
-  event?: {
-    type: string;
-    delta?: {
-      type: string;
-      text?: string;
-    };
-  };
-  result?: string;
-}
-
-export class HostChatSession {
-  private process: Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+export class HostChatSession extends BaseClaudeSession {
   private workDir: string;
-  private sessionId?: string;
-  private model: string;
-  private onMessage: (message: ChatMessage) => void;
-  private buffer: string = '';
 
-  constructor(options: HostChatOptions, onMessage: (message: ChatMessage) => void) {
+  constructor(options: HostChatOptions, onMessage: MessageCallback) {
+    super(options.sessionId, options.model, onMessage);
     this.workDir = options.workDir || homedir();
-    this.sessionId = options.sessionId;
-    this.model = options.model || 'sonnet';
-    this.onMessage = onMessage;
   }
 
-  async sendMessage(userMessage: string): Promise<void> {
+  protected getLogPrefix(): string {
+    return 'host-chat';
+  }
+
+  protected getSpawnConfig(userMessage: string): SpawnConfig {
     const args = [
+      'claude',
       '--print',
       '--verbose',
       '--output-format',
@@ -65,165 +35,15 @@ export class HostChatSession {
 
     args.push(userMessage);
 
-    console.log('[host-chat] Running: claude', args.join(' '));
-
-    this.onMessage({
-      type: 'system',
-      content: 'Processing your message...',
-      timestamp: new Date().toISOString(),
-    });
-
-    try {
-      const proc = Bun.spawn(['claude', ...args], {
+    return {
+      command: args,
+      options: {
         cwd: this.workDir,
-        stdin: 'ignore',
-        stdout: 'pipe',
-        stderr: 'pipe',
         env: {
           ...process.env,
         },
-      });
-
-      this.process = proc;
-
-      if (!proc.stdout || !proc.stderr) {
-        throw new Error('Failed to get process streams');
-      }
-
-      console.log('[host-chat] Process spawned, waiting for output...');
-
-      const stderrPromise = new Response(proc.stderr).text();
-
-      const decoder = new TextDecoder();
-      let receivedAnyOutput = false;
-
-      for await (const chunk of proc.stdout) {
-        const text = decoder.decode(chunk);
-        console.log('[host-chat] Received chunk:', text.length, 'bytes');
-        receivedAnyOutput = true;
-        this.buffer += text;
-        this.processBuffer();
-      }
-
-      const exitCode = await proc.exited;
-      console.log(
-        '[host-chat] Process exited with code:',
-        exitCode,
-        'receivedOutput:',
-        receivedAnyOutput
-      );
-
-      const stderrText = await stderrPromise;
-      if (stderrText) {
-        console.error('[host-chat] stderr:', stderrText);
-      }
-
-      if (exitCode !== 0) {
-        this.onMessage({
-          type: 'error',
-          content: stderrText || `Claude exited with code ${exitCode}`,
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      if (!receivedAnyOutput) {
-        this.onMessage({
-          type: 'error',
-          content: 'No response from Claude. Check if Claude is authenticated.',
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      this.onMessage({
-        type: 'done',
-        content: 'Response complete',
-        timestamp: new Date().toISOString(),
-      });
-    } catch (err) {
-      console.error('[host-chat] Error:', err);
-      this.onMessage({
-        type: 'error',
-        content: (err as Error).message,
-        timestamp: new Date().toISOString(),
-      });
-    } finally {
-      this.process = null;
-    }
-  }
-
-  private processBuffer(): void {
-    const lines = this.buffer.split('\n');
-    this.buffer = lines.pop() || '';
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      try {
-        const msg: StreamMessage = JSON.parse(line);
-        this.handleStreamMessage(msg);
-      } catch {
-        console.error('[host-chat] Failed to parse:', line);
-      }
-    }
-  }
-
-  private handleStreamMessage(msg: StreamMessage): void {
-    const timestamp = new Date().toISOString();
-
-    if (msg.type === 'system' && msg.subtype === 'init') {
-      this.sessionId = msg.session_id;
-      this.onMessage({
-        type: 'system',
-        content: `Session started: ${msg.session_id?.slice(0, 8)}...`,
-        timestamp,
-      });
-      return;
-    }
-
-    if (msg.type === 'assistant' && msg.message?.content) {
-      for (const block of msg.message.content) {
-        if (block.type === 'tool_use') {
-          this.onMessage({
-            type: 'tool_use',
-            content: JSON.stringify(block.input, null, 2),
-            toolName: block.name,
-            toolId: block.id,
-            timestamp,
-          });
-        }
-      }
-      return;
-    }
-
-    if (msg.type === 'stream_event' && msg.event?.type === 'content_block_delta') {
-      const delta = msg.event?.delta;
-      if (delta?.type === 'text_delta' && delta?.text) {
-        this.onMessage({
-          type: 'assistant',
-          content: delta.text,
-          timestamp,
-        });
-      }
-      return;
-    }
-  }
-
-  async interrupt(): Promise<void> {
-    if (this.process) {
-      this.process.kill();
-      this.process = null;
-      this.onMessage({
-        type: 'system',
-        content: 'Chat interrupted',
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  getSessionId(): string | undefined {
-    return this.sessionId;
+      },
+    };
   }
 }
 

--- a/src/chat/host-opencode-handler.ts
+++ b/src/chat/host-opencode-handler.ts
@@ -1,53 +1,49 @@
-import type { Subprocess } from 'bun';
-import type { ChatMessage } from './handler';
 import { homedir } from 'os';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { BaseOpencodeSession } from './base-opencode-session';
+import type { ChatMessage, MessageCallback, SpawnConfig, HostChatOptions } from './types';
 
-export interface HostOpencodeOptions {
-  workDir?: string;
-  sessionId?: string;
-  model?: string;
-}
+export type { HostChatOptions as HostOpencodeOptions };
 
-interface OpencodeStreamEvent {
-  type: string;
-  timestamp?: number;
-  sessionID?: string;
-  part?: {
-    id?: string;
-    sessionID?: string;
-    messageID?: string;
-    type: string;
-    text?: string;
-    tool?: string;
-    callID?: string;
-    state?: {
-      status?: string;
-      input?: Record<string, unknown>;
-      output?: string;
-      title?: string;
-    };
-    reason?: string;
-  };
-}
-
-export class HostOpencodeSession {
-  private process: Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+export class HostOpencodeSession extends BaseOpencodeSession {
   private workDir: string;
-  private sessionId?: string;
-  private model?: string;
-  private sessionModel?: string;
-  private onMessage: (message: ChatMessage) => void;
-  private buffer: string = '';
-  private historyLoaded: boolean = false;
 
-  constructor(options: HostOpencodeOptions, onMessage: (message: ChatMessage) => void) {
+  constructor(options: HostChatOptions, onMessage: MessageCallback) {
+    super(options.sessionId, options.model, onMessage);
     this.workDir = options.workDir || homedir();
-    this.sessionId = options.sessionId;
-    this.model = options.model;
-    this.sessionModel = options.model;
-    this.onMessage = onMessage;
+  }
+
+  protected getLogPrefix(): string {
+    return 'host-opencode';
+  }
+
+  protected getNoOutputErrorMessage(): string {
+    return 'No response from OpenCode. Check if OpenCode is installed and configured.';
+  }
+
+  protected getSpawnConfig(userMessage: string): SpawnConfig {
+    const args = ['stdbuf', '-oL', 'opencode', 'run', '--format', 'json'];
+
+    if (this.sessionId) {
+      args.push('--session', this.sessionId);
+    }
+
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+
+    args.push(userMessage);
+
+    return {
+      command: args,
+      options: {
+        cwd: this.workDir,
+        env: {
+          ...process.env,
+        },
+      },
+    };
   }
 
   async loadHistory(): Promise<void> {
@@ -185,219 +181,10 @@ export class HostOpencodeSession {
       console.error('[host-opencode] Failed to load history:', err);
     }
   }
-
-  async sendMessage(userMessage: string): Promise<void> {
-    if (this.sessionId && !this.historyLoaded) {
-      await this.loadHistory();
-    }
-
-    const args = ['-oL', 'opencode', 'run', '--format', 'json'];
-
-    if (this.sessionId) {
-      args.push('--session', this.sessionId);
-    }
-
-    if (this.model) {
-      args.push('--model', this.model);
-    }
-
-    args.push(userMessage);
-
-    console.log('[host-opencode] Running: stdbuf', args.join(' '));
-
-    this.onMessage({
-      type: 'system',
-      content: 'Processing your message...',
-      timestamp: new Date().toISOString(),
-    });
-
-    try {
-      const proc = Bun.spawn(['stdbuf', ...args], {
-        cwd: this.workDir,
-        stdin: 'ignore',
-        stdout: 'pipe',
-        stderr: 'pipe',
-        env: {
-          ...process.env,
-        },
-      });
-
-      this.process = proc;
-
-      if (!proc.stdout || !proc.stderr) {
-        throw new Error('Failed to get process streams');
-      }
-
-      console.log('[host-opencode] Process spawned, waiting for output...');
-
-      const stderrPromise = new Response(proc.stderr).text();
-
-      const decoder = new TextDecoder();
-      let receivedAnyOutput = false;
-
-      for await (const chunk of proc.stdout) {
-        const text = decoder.decode(chunk);
-        console.log('[host-opencode] Received chunk:', text.length, 'bytes');
-        receivedAnyOutput = true;
-        this.buffer += text;
-        this.processBuffer();
-      }
-
-      const exitCode = await proc.exited;
-      console.log(
-        '[host-opencode] Process exited with code:',
-        exitCode,
-        'receivedOutput:',
-        receivedAnyOutput
-      );
-
-      const stderrText = await stderrPromise;
-      if (stderrText) {
-        console.error('[host-opencode] stderr:', stderrText);
-      }
-
-      if (exitCode !== 0) {
-        this.onMessage({
-          type: 'error',
-          content: stderrText || `OpenCode exited with code ${exitCode}`,
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      if (!receivedAnyOutput) {
-        this.onMessage({
-          type: 'error',
-          content: 'No response from OpenCode. Check if OpenCode is installed and configured.',
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      this.onMessage({
-        type: 'done',
-        content: 'Response complete',
-        timestamp: new Date().toISOString(),
-      });
-    } catch (err) {
-      console.error('[host-opencode] Error:', err);
-      this.onMessage({
-        type: 'error',
-        content: (err as Error).message,
-        timestamp: new Date().toISOString(),
-      });
-    } finally {
-      this.process = null;
-    }
-  }
-
-  private processBuffer(): void {
-    const lines = this.buffer.split('\n');
-    this.buffer = lines.pop() || '';
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      try {
-        const event: OpencodeStreamEvent = JSON.parse(line);
-        this.handleStreamEvent(event);
-      } catch {
-        console.error('[host-opencode] Failed to parse:', line);
-      }
-    }
-  }
-
-  private handleStreamEvent(event: OpencodeStreamEvent): void {
-    const timestamp = new Date().toISOString();
-
-    if (event.type === 'step_start' && event.sessionID) {
-      if (!this.sessionId) {
-        this.sessionId = event.sessionID;
-        this.sessionModel = this.model;
-        this.historyLoaded = true;
-        this.onMessage({
-          type: 'system',
-          content: `Session started ${this.sessionId}`,
-          timestamp,
-        });
-      }
-      return;
-    }
-
-    if (event.type === 'text' && event.part?.text) {
-      this.onMessage({
-        type: 'assistant',
-        content: event.part.text,
-        timestamp,
-      });
-      return;
-    }
-
-    if (event.type === 'tool_use' && event.part) {
-      const toolName = event.part.tool || 'unknown';
-      const toolId = event.part.callID || event.part.id;
-      const input = event.part.state?.input;
-      const output = event.part.state?.output;
-      const title =
-        event.part.state?.title || (input as { description?: string })?.description || toolName;
-
-      console.log('[host-opencode] Tool use:', toolName, title);
-
-      this.onMessage({
-        type: 'tool_use',
-        content: JSON.stringify(input, null, 2),
-        toolName: title || toolName,
-        toolId,
-        timestamp,
-      });
-
-      if (output) {
-        this.onMessage({
-          type: 'tool_result',
-          content: output,
-          toolName,
-          toolId,
-          timestamp,
-        });
-      }
-      return;
-    }
-  }
-
-  async interrupt(): Promise<void> {
-    if (this.process) {
-      this.process.kill();
-      this.process = null;
-      this.onMessage({
-        type: 'system',
-        content: 'Chat interrupted',
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  setModel(model: string): void {
-    if (this.model !== model) {
-      this.model = model;
-      if (this.sessionModel !== model) {
-        this.sessionId = undefined;
-        this.historyLoaded = false;
-        this.onMessage({
-          type: 'system',
-          content: `Switching to model: ${model}`,
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  getSessionId(): string | undefined {
-    return this.sessionId;
-  }
 }
 
 export function createHostOpencodeSession(
-  options: HostOpencodeOptions,
+  options: HostChatOptions,
   onMessage: (message: ChatMessage) => void
 ): HostOpencodeSession {
   return new HostOpencodeSession(options, onMessage);

--- a/src/chat/opencode-handler.ts
+++ b/src/chat/opencode-handler.ts
@@ -1,55 +1,60 @@
-import type { Subprocess } from 'bun';
-import type { ChatMessage } from './handler';
+import { BaseOpencodeSession } from './base-opencode-session';
+import type { ChatMessage, MessageCallback, SpawnConfig, ContainerChatOptions } from './types';
 import { opencodeProvider } from '../sessions/agents/opencode';
 import type { ExecInContainer } from '../sessions/agents/types';
 
-export interface OpencodeOptions {
-  containerName: string;
-  workDir?: string;
-  sessionId?: string;
-  model?: string;
-}
+export interface OpencodeOptions extends ContainerChatOptions {}
 
-interface OpencodeStreamEvent {
-  type: string;
-  timestamp?: number;
-  sessionID?: string;
-  part?: {
-    id?: string;
-    sessionID?: string;
-    messageID?: string;
-    type: string;
-    text?: string;
-    tool?: string;
-    callID?: string;
-    state?: {
-      status?: string;
-      input?: Record<string, unknown>;
-      output?: string;
-      title?: string;
-    };
-    reason?: string;
-  };
-}
-
-export class OpencodeSession {
-  private process: Subprocess<'ignore', 'pipe', 'pipe'> | null = null;
+export class OpencodeSession extends BaseOpencodeSession {
   private containerName: string;
   private workDir: string;
-  private sessionId?: string;
-  private model?: string;
-  private sessionModel?: string;
-  private onMessage: (message: ChatMessage) => void;
-  private buffer: string = '';
-  private historyLoaded: boolean = false;
 
-  constructor(options: OpencodeOptions, onMessage: (message: ChatMessage) => void) {
+  constructor(options: OpencodeOptions, onMessage: MessageCallback) {
+    super(options.sessionId, options.model, onMessage);
     this.containerName = options.containerName;
     this.workDir = options.workDir || '/home/workspace';
-    this.sessionId = options.sessionId;
-    this.model = options.model;
-    this.sessionModel = options.model;
-    this.onMessage = onMessage;
+  }
+
+  protected getLogPrefix(): string {
+    return 'opencode';
+  }
+
+  protected getNoOutputErrorMessage(): string {
+    return 'No response from OpenCode. Check if OpenCode is configured in the workspace.';
+  }
+
+  protected getSpawnConfig(userMessage: string): SpawnConfig {
+    const args = [
+      'docker',
+      'exec',
+      '-i',
+      '-u',
+      'workspace',
+      '-w',
+      this.workDir,
+      this.containerName,
+      'stdbuf',
+      '-oL',
+      'opencode',
+      'run',
+      '--format',
+      'json',
+    ];
+
+    if (this.sessionId) {
+      args.push('--session', this.sessionId);
+    }
+
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+
+    args.push(userMessage);
+
+    return {
+      command: args,
+      options: {},
+    };
   }
 
   async loadHistory(): Promise<void> {
@@ -114,225 +119,6 @@ export class OpencodeSession {
     } catch (err) {
       console.error('[opencode] Failed to load history:', err);
     }
-  }
-
-  async sendMessage(userMessage: string): Promise<void> {
-    if (this.sessionId && !this.historyLoaded) {
-      await this.loadHistory();
-    }
-
-    const args = [
-      'exec',
-      '-i',
-      '-u',
-      'workspace',
-      '-w',
-      this.workDir,
-      this.containerName,
-      'stdbuf',
-      '-oL',
-      'opencode',
-      'run',
-      '--format',
-      'json',
-    ];
-
-    if (this.sessionId) {
-      args.push('--session', this.sessionId);
-    }
-
-    if (this.model) {
-      args.push('--model', this.model);
-    }
-
-    args.push(userMessage);
-
-    console.log('[opencode] Running:', 'docker', args.join(' '));
-
-    this.onMessage({
-      type: 'system',
-      content: 'Processing your message...',
-      timestamp: new Date().toISOString(),
-    });
-
-    try {
-      const proc = Bun.spawn(['docker', ...args], {
-        stdin: 'ignore',
-        stdout: 'pipe',
-        stderr: 'pipe',
-      });
-
-      this.process = proc;
-
-      if (!proc.stdout || !proc.stderr) {
-        throw new Error('Failed to get process streams');
-      }
-
-      console.log('[opencode] Process spawned, waiting for output...');
-
-      const stderrPromise = new Response(proc.stderr).text();
-
-      const decoder = new TextDecoder();
-      let receivedAnyOutput = false;
-
-      for await (const chunk of proc.stdout) {
-        const text = decoder.decode(chunk);
-        console.log('[opencode] Received chunk:', text.length, 'bytes');
-        receivedAnyOutput = true;
-        this.buffer += text;
-        this.processBuffer();
-      }
-
-      const exitCode = await proc.exited;
-      console.log(
-        '[opencode] Process exited with code:',
-        exitCode,
-        'receivedOutput:',
-        receivedAnyOutput
-      );
-
-      const stderrText = await stderrPromise;
-      if (stderrText) {
-        console.error('[opencode] stderr:', stderrText);
-      }
-
-      if (exitCode !== 0) {
-        this.onMessage({
-          type: 'error',
-          content: stderrText || `OpenCode exited with code ${exitCode}`,
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      if (!receivedAnyOutput) {
-        this.onMessage({
-          type: 'error',
-          content: 'No response from OpenCode. Check if OpenCode is configured in the workspace.',
-          timestamp: new Date().toISOString(),
-        });
-        return;
-      }
-
-      this.onMessage({
-        type: 'done',
-        content: 'Response complete',
-        timestamp: new Date().toISOString(),
-      });
-    } catch (err) {
-      console.error('[opencode] Error:', err);
-      this.onMessage({
-        type: 'error',
-        content: (err as Error).message,
-        timestamp: new Date().toISOString(),
-      });
-    } finally {
-      this.process = null;
-    }
-  }
-
-  private processBuffer(): void {
-    const lines = this.buffer.split('\n');
-    this.buffer = lines.pop() || '';
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      try {
-        const event: OpencodeStreamEvent = JSON.parse(line);
-        this.handleStreamEvent(event);
-      } catch {
-        console.error('[opencode] Failed to parse:', line);
-      }
-    }
-  }
-
-  private handleStreamEvent(event: OpencodeStreamEvent): void {
-    const timestamp = new Date().toISOString();
-
-    if (event.type === 'step_start' && event.sessionID) {
-      if (!this.sessionId) {
-        this.sessionId = event.sessionID;
-        this.sessionModel = this.model;
-        this.historyLoaded = true;
-        this.onMessage({
-          type: 'system',
-          content: `Session started ${this.sessionId}`,
-          timestamp,
-        });
-      }
-      return;
-    }
-
-    if (event.type === 'text' && event.part?.text) {
-      this.onMessage({
-        type: 'assistant',
-        content: event.part.text,
-        timestamp,
-      });
-      return;
-    }
-
-    if (event.type === 'tool_use' && event.part) {
-      const toolName = event.part.tool || 'unknown';
-      const toolId = event.part.callID || event.part.id;
-      const input = event.part.state?.input;
-      const output = event.part.state?.output;
-      const title =
-        event.part.state?.title || (input as { description?: string })?.description || toolName;
-
-      console.log('[opencode] Tool use:', toolName, title);
-
-      this.onMessage({
-        type: 'tool_use',
-        content: JSON.stringify(input, null, 2),
-        toolName: title || toolName,
-        toolId,
-        timestamp,
-      });
-
-      if (output) {
-        this.onMessage({
-          type: 'tool_result',
-          content: output,
-          toolName,
-          toolId,
-          timestamp,
-        });
-      }
-      return;
-    }
-  }
-
-  async interrupt(): Promise<void> {
-    if (this.process) {
-      this.process.kill();
-      this.process = null;
-      this.onMessage({
-        type: 'system',
-        content: 'Chat interrupted',
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  setModel(model: string): void {
-    if (this.model !== model) {
-      this.model = model;
-      if (this.sessionModel !== model) {
-        this.sessionId = undefined;
-        this.historyLoaded = false;
-        this.onMessage({
-          type: 'system',
-          content: `Switching to model: ${model}`,
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  getSessionId(): string | undefined {
-    return this.sessionId;
   }
 }
 

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -1,0 +1,81 @@
+import type { Subprocess } from 'bun';
+
+export interface ChatMessage {
+  type: 'user' | 'assistant' | 'system' | 'tool_use' | 'tool_result' | 'error' | 'done';
+  content: string;
+  timestamp: string;
+  toolName?: string;
+  toolId?: string;
+}
+
+export interface ClaudeStreamMessage {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  model?: string;
+  message?: {
+    content?: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      id?: string;
+      input?: unknown;
+    }>;
+  };
+  event?: {
+    type: string;
+    delta?: {
+      type: string;
+      text?: string;
+    };
+  };
+  result?: string;
+}
+
+export interface OpencodeStreamEvent {
+  type: string;
+  timestamp?: number;
+  sessionID?: string;
+  part?: {
+    id?: string;
+    sessionID?: string;
+    messageID?: string;
+    type: string;
+    text?: string;
+    tool?: string;
+    callID?: string;
+    state?: {
+      status?: string;
+      input?: Record<string, unknown>;
+      output?: string;
+      title?: string;
+    };
+    reason?: string;
+  };
+}
+
+export type ChatProcess = Subprocess<'ignore', 'pipe', 'pipe'>;
+
+export type MessageCallback = (message: ChatMessage) => void;
+
+export interface SpawnConfig {
+  command: string[];
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  };
+}
+
+export interface BaseChatOptions {
+  sessionId?: string;
+  model?: string;
+}
+
+export interface ContainerChatOptions extends BaseChatOptions {
+  containerName: string;
+  workDir?: string;
+}
+
+export interface HostChatOptions extends BaseChatOptions {
+  workDir?: string;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,5 +1,7 @@
 export const DEFAULT_AGENT_PORT = 7391;
 
+export const DEFAULT_CLAUDE_MODEL = 'sonnet';
+
 export const SSH_PORT_RANGE_START = 2200;
 export const SSH_PORT_RANGE_END = 2400;
 


### PR DESCRIPTION
## Summary

- Refactor to eliminate ~95% code duplication between container and host chat handlers
- Create abstract base classes `BaseClaudeSession` and `BaseOpencodeSession` with shared logic
- Each handler now only implements spawn configuration and context-specific messages
- Reduces code from ~850 lines to ~600 lines total (with better separation of concerns)

### Changes

- Create `src/chat/types.ts` with shared interfaces
- Create `src/chat/base-claude-session.ts` for Claude Code handlers
- Create `src/chat/base-opencode-session.ts` for OpenCode handlers
- Update all 4 handlers to extend base classes
- Add `DEFAULT_CLAUDE_MODEL` constant

## Test plan

- [x] All existing tests pass (101/101)
- [x] Build succeeds
- [x] Lint/typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)