### PR TITLE
Fix --clone flag not working when starting workspace

### DIFF
--- a/perry/internal/src/commands/entrypoint.ts
+++ b/perry/internal/src/commands/entrypoint.ts
@@ -1,4 +1,5 @@
 import { addSshKeys } from "./add-ssh-key";
+import { runInit } from "./init";
 import { syncUserWithHost } from "./sync-user";
 import { ensureDockerd, monitorServices, startSshd, tailDockerdLogs, waitForDocker } from "../lib/services";
 
@@ -18,6 +19,8 @@ export const runEntrypoint = async () => {
     process.exit(1);
     return;
   }
+  console.log("[entrypoint] Running workspace initialization...");
+  await runInit();
   console.log("[entrypoint] Starting SSH daemon...");
   await startSshd();
   void monitorServices();


### PR DESCRIPTION
## Summary

- Fixed the `--clone` flag not working when starting a workspace with `perry start <name> --clone <url>`
- The root cause was that the container's `init` command (which handles git cloning) was never being called during container startup
- Added integration test that verifies the repository is actually cloned inside the workspace

## Changes

- `perry/internal/src/commands/entrypoint.ts`: Call `runInit()` after Docker daemon is ready
- `test/integration/cli.test.ts`: Enhanced clone test to wait for init completion and verify the repo exists

## Test plan

- [x] `bun run validate` passes
- [x] Manual test: `perry start test-clone --clone https://github.com/octocat/Hello-World` creates workspace with cloned repo
- [x] Integration test verifies `.workspace-initialized` marker exists and `Hello-World/.git` directory is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)