### PR TITLE
Fix streaming message jitter in chat UI

### DIFF
--- a/test/web/workspace.spec.ts
+++ b/test/web/workspace.spec.ts
@@ -202,8 +202,8 @@ test.describe('Web UI - Sessions', () => {
     const sessionId = `test-session-${Date.now()}`;
     const filePath = `/home/workspace/.claude/projects/-workspace/${sessionId}.jsonl`;
     const sessionContent = [
-      '{"type":"user","message":{"role":"user","content":"Hello from test"},"timestamp":"2026-01-01T00:00:00.000Z"}',
-      '{"type":"assistant","message":{"role":"assistant","content":"Hi there"},"timestamp":"2026-01-01T00:00:01.000Z"}',
+      '{"type":"user","content":"Hello from test","timestamp":"2026-01-01T00:00:00.000Z"}',
+      '{"type":"assistant","content":"Hi there","timestamp":"2026-01-01T00:00:01.000Z"}',
     ].join('\n');
 
     await agent.api.createWorkspace({ name: workspaceName });
@@ -222,7 +222,7 @@ test.describe('Web UI - Sessions', () => {
 
       await sessionItem.click();
 
-      await expect(page.getByText('Claude Code')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('Claude Code', { exact: true })).toBeVisible({ timeout: 30000 });
       await expect(page.getByPlaceholder('Send a message...')).toBeVisible();
     } finally {
       await agent.api.deleteWorkspace(workspaceName);
@@ -234,10 +234,10 @@ test.describe('Web UI - Sessions', () => {
     const sessionId = `history-test-${Date.now()}`;
     const filePath = `/home/workspace/.claude/projects/-workspace/${sessionId}.jsonl`;
     const sessionContent = [
-      '{"type":"user","message":{"role":"user","content":"What is 2+2?"},"timestamp":"2026-01-01T00:00:00.000Z"}',
-      '{"type":"assistant","message":{"role":"assistant","content":"2+2 equals 4"},"timestamp":"2026-01-01T00:00:01.000Z"}',
-      '{"type":"user","message":{"role":"user","content":"Thanks!"},"timestamp":"2026-01-01T00:00:02.000Z"}',
-      '{"type":"assistant","message":{"role":"assistant","content":"You are welcome!"},"timestamp":"2026-01-01T00:00:03.000Z"}',
+      '{"type":"user","content":"What is 2+2?","timestamp":"2026-01-01T00:00:00.000Z"}',
+      '{"type":"assistant","content":"2+2 equals 4","timestamp":"2026-01-01T00:00:01.000Z"}',
+      '{"type":"user","content":"Thanks!","timestamp":"2026-01-01T00:00:02.000Z"}',
+      '{"type":"assistant","content":"You are welcome!","timestamp":"2026-01-01T00:00:03.000Z"}',
     ].join('\n');
 
     await agent.api.createWorkspace({ name: workspaceName });
@@ -256,7 +256,7 @@ test.describe('Web UI - Sessions', () => {
 
       await sessionItem.click();
 
-      await expect(page.getByText('Claude Code')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('Claude Code', { exact: true })).toBeVisible({ timeout: 30000 });
       await expect(page.getByText('2+2 equals 4')).toBeVisible({ timeout: 10000 });
       await expect(page.getByText('Thanks!')).toBeVisible();
       await expect(page.getByText('You are welcome!')).toBeVisible();

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -540,6 +540,7 @@ export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, 
             if (match) {
               const newSessionId = match[1].replace(/\.+$/, '')
               setSessionId(newSessionId)
+              hasLoadedHistoryRef.current = true
               onSessionIdRef.current?.(newSessionId)
             }
             return
@@ -719,14 +720,14 @@ export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, 
       )}
 
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
-        {isLoadingHistory && (
+        {isLoadingHistory && messages.length === 0 && (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
             <Loader2 className="h-8 w-8 animate-spin mb-4" />
             <p className="text-center">Loading conversation history...</p>
           </div>
         )}
 
-        {!isLoadingHistory && messages.length === 0 && !isStreaming && (
+        {messages.length === 0 && !isLoadingHistory && !isStreaming && (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4">
             <Sparkles className="h-12 w-12 mb-4 opacity-20" />
             <p className="text-center">
@@ -738,7 +739,7 @@ export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, 
           </div>
         )}
 
-        {!isLoadingHistory && messages.length > 0 && containerMounted && (
+        {messages.length > 0 && containerMounted && (
           <>
             {isLoadingMore && (
               <div className="flex justify-center py-4">
@@ -786,7 +787,7 @@ export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, 
           </>
         )}
 
-        {!isLoadingHistory && messages.length > 0 && !containerMounted && (
+        {messages.length > 0 && !containerMounted && (
           <div className="space-y-4 p-4">
             {messages.map((msg, idx) => (
               <MessageBubble key={idx} message={msg} />
@@ -794,7 +795,7 @@ export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, 
           </div>
         )}
 
-        {isStreaming && (
+        {isStreaming && messages.length > 0 && (
           <div className="p-4 pt-0">
             <StreamingMessage parts={streamingParts} />
           </div>

--- a/web/src/pages/WorkspaceDetail.tsx
+++ b/web/src/pages/WorkspaceDetail.tsx
@@ -568,6 +568,7 @@ export function WorkspaceDetail() {
             ) : chatMode ? (
               chatMode.type === 'chat' ? (
                 <Chat
+                  key={`chat-${chatMode.agentType}`}
                   workspaceName={name!}
                   sessionId={chatMode.sessionId}
                   agentType={chatMode.agentType}


### PR DESCRIPTION
## Summary
- Only show streaming indicator when `messages.length > 0`, preventing the brief flash of just bouncing dots before the user message appears
- Fix test session file format to match `parseMessages` expectations
- Use exact text matching in tests to avoid ambiguous selectors

## Test plan
- [x] All 20 web UI tests pass
- [x] Manual testing confirms jitter is eliminated when sending first message in new chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)