### PR TITLE
Fix Claude Code session resume with correct project path

### DIFF
--- a/mobile/src/screens/SessionChatScreen.tsx
+++ b/mobile/src/screens/SessionChatScreen.tsx
@@ -251,7 +251,7 @@ function StreamingBubble({ parts }: { parts: MessagePart[] }) {
 
 export function SessionChatScreen({ route, navigation }: any) {
   const insets = useSafeAreaInsets()
-  const { workspaceName, sessionId: initialSessionId, agentType = 'claude-code', isNew } = route.params
+  const { workspaceName, sessionId: initialSessionId, agentType = 'claude-code', isNew, projectPath } = route.params
 
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
@@ -564,6 +564,10 @@ export function SessionChatScreen({ route, navigation }: any) {
 
     if (selectedModel) {
       payload.model = selectedModel
+    }
+
+    if (projectPath) {
+      payload.projectPath = projectPath
     }
 
     wsRef.current.send(JSON.stringify(payload))

--- a/mobile/src/screens/WorkspaceDetailScreen.tsx
+++ b/mobile/src/screens/WorkspaceDetailScreen.tsx
@@ -358,6 +358,7 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
                   workspaceName: name,
                   sessionId: item.session.id,
                   agentType: item.session.agentType,
+                  projectPath: item.session.projectPath,
                 })}
               />
             )

--- a/src/chat/base-chat-websocket.ts
+++ b/src/chat/base-chat-websocket.ts
@@ -19,6 +19,7 @@ export interface IncomingChatMessage {
   content?: string;
   sessionId?: string;
   model?: string;
+  projectPath?: string;
 }
 
 export interface BaseChatWebSocketOptions {
@@ -40,7 +41,8 @@ export abstract class BaseChatWebSocketServer<
   protected abstract createHostSession(
     sessionId: string | undefined,
     onMessage: (message: ChatMessage) => void,
-    model?: string
+    model?: string,
+    projectPath?: string
   ): ChatSessionInterface;
 
   protected abstract createContainerSession(
@@ -97,7 +99,8 @@ export abstract class BaseChatWebSocketServer<
               connection.session = this.createHostSession(
                 message.sessionId,
                 onMessage,
-                message.model
+                message.model,
+                message.projectPath
               );
             } else {
               const containerName = getContainerName(workspaceName);

--- a/src/chat/opencode-websocket.ts
+++ b/src/chat/opencode-websocket.ts
@@ -44,7 +44,8 @@ export class OpencodeWebSocketServer extends BaseChatWebSocketServer<OpencodeCon
   protected createHostSession(
     sessionId: string | undefined,
     onMessage: (message: ChatMessage) => void,
-    messageModel?: string
+    messageModel?: string,
+    _projectPath?: string
   ): ChatSessionInterface {
     const model = messageModel || this.getConfig?.()?.agents?.opencode?.model;
     return createHostOpencodeSession({ sessionId, model }, onMessage);

--- a/src/chat/websocket.ts
+++ b/src/chat/websocket.ts
@@ -41,11 +41,12 @@ export class ChatWebSocketServer extends BaseChatWebSocketServer<ChatConnection>
   protected createHostSession(
     sessionId: string | undefined,
     onMessage: (message: ChatMessage) => void,
-    messageModel?: string
+    messageModel?: string,
+    projectPath?: string
   ): ChatSessionInterface {
     const config = this.getConfig();
     const model = messageModel || config.agents?.claude_code?.model;
-    return createHostChatSession({ sessionId, model }, onMessage);
+    return createHostChatSession({ sessionId, model, workDir: projectPath }, onMessage);
   }
 
   protected createContainerSession(

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -34,6 +34,7 @@ interface RawMessage {
 interface ChatProps {
   workspaceName: string
   sessionId?: string
+  projectPath?: string
   onSessionId?: (sessionId: string) => void
   agentType?: AgentType
   hideHeader?: boolean
@@ -239,7 +240,7 @@ function StreamingMessage({ parts }: { parts: ChatMessagePart[] }) {
 
 const MESSAGES_PER_PAGE = 50
 
-export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, agentType = 'claude-code', hideHeader, onConnectionChange, onBack }: ChatProps) {
+export function Chat({ workspaceName, sessionId: initialSessionId, projectPath, onSessionId, agentType = 'claude-code', hideHeader, onConnectionChange, onBack }: ChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [isConnected, setIsConnected] = useState(false)
@@ -626,13 +627,17 @@ export function Chat({ workspaceName, sessionId: initialSessionId, onSessionId, 
       messagePayload.model = selectedModel
     }
 
+    if (projectPath) {
+      messagePayload.projectPath = projectPath
+    }
+
     wsRef.current.send(JSON.stringify(messagePayload))
 
     setInput('')
     setIsStreaming(true)
     streamingPartsRef.current = []
     setStreamingParts([])
-  }, [input, sessionId, selectedModel])
+  }, [input, sessionId, selectedModel, projectPath])
 
   const interrupt = useCallback(() => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {

--- a/web/src/pages/WorkspaceDetail.tsx
+++ b/web/src/pages/WorkspaceDetail.tsx
@@ -224,7 +224,7 @@ function SessionListItem({
   )
 }
 
-type ChatMode = { type: 'chat'; sessionId?: string; agentType?: AgentType } | { type: 'terminal'; command: string }
+type ChatMode = { type: 'chat'; sessionId?: string; agentType?: AgentType; projectPath?: string } | { type: 'terminal'; command: string }
 
 export function WorkspaceDetail() {
   const { name: rawName } = useParams<{ name: string }>()
@@ -360,9 +360,9 @@ export function WorkspaceDetail() {
     },
   })
 
-  const handleResume = (sessionId: string, agentType: AgentType) => {
+  const handleResume = (sessionId: string, agentType: AgentType, projectPath?: string) => {
     if (agentType === 'claude-code' || agentType === 'opencode') {
-      setChatMode({ type: 'chat', sessionId, agentType })
+      setChatMode({ type: 'chat', sessionId, agentType, projectPath })
     } else {
       const commands: Record<AgentType, string> = {
         'claude-code': `claude -r ${sessionId}`,
@@ -572,6 +572,7 @@ export function WorkspaceDetail() {
                   workspaceName={name!}
                   sessionId={chatMode.sessionId}
                   agentType={chatMode.agentType}
+                  projectPath={chatMode.projectPath}
                   onSessionId={handleSessionId}
                   onBack={() => setChatMode(null)}
                 />
@@ -713,7 +714,7 @@ export function WorkspaceDetail() {
                               <SessionListItem
                                 key={session.id}
                                 session={session}
-                                onClick={() => handleResume(session.id, session.agentType)}
+                                onClick={() => handleResume(session.id, session.agentType, session.projectPath)}
                                 onDelete={() => setDeleteSessionDialog(session)}
                               />
                             ))}


### PR DESCRIPTION
## Summary

- Fix Claude Code session resume failing with "No conversation found with session ID" when resuming sessions created via interactive CLI
- Thread `projectPath` from session listing through web/mobile UI to chat handler
- Pass `projectPath` as working directory when spawning Claude Code process
- Add Playwright test to verify `projectPath` is sent in WebSocket messages
- Document OpenCode session resume bug in TODO.md for later fix

## Root Cause

When resuming a session, Perry was running Claude with `cwd=homedir()` instead of the original project directory. Claude uses the working directory to determine which project folder to search for sessions (stored in `~/.claude/projects/<project-name-dashed>/<sessionId>.jsonl`).

## Test plan

- [x] New Playwright test verifies `projectPath` is sent in WebSocket message when resuming session
- [x] All 108 integration tests pass
- [x] All 21 web UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)