### PR TITLE
Remove host access toggle from web UI

### DIFF
--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -1000,21 +1000,6 @@ export function createRouter(ctx: RouterContext) {
     };
   });
 
-  const updateHostAccess = os
-    .input(z.object({ enabled: z.boolean() }))
-    .handler(async ({ input }) => {
-      const currentConfig = ctx.config.get();
-      const newConfig = { ...currentConfig, allowHostAccess: input.enabled };
-      ctx.config.set(newConfig);
-      await saveAgentConfig(newConfig, ctx.configDir);
-      return {
-        enabled: input.enabled,
-        hostname: os_module.hostname(),
-        username: os_module.userInfo().username,
-        homeDir: os_module.homedir(),
-      };
-    });
-
   const listModels = os
     .input(
       z.object({
@@ -1105,7 +1090,6 @@ export function createRouter(ctx: RouterContext) {
     },
     host: {
       info: getHostInfo,
-      updateAccess: updateHostAccess,
     },
     info: getInfo,
     config: {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -143,7 +143,6 @@ export const api = {
   getAgents: () => client.config.agents.get(),
   updateAgents: (data: CodingAgents) => client.config.agents.update(data),
   getHostInfo: () => client.host.info(),
-  updateHostAccess: (enabled: boolean) => client.host.updateAccess({ enabled }),
   getSSHSettings: () => client.config.ssh.get(),
   updateSSHSettings: (data: SSHSettings) => client.config.ssh.update(data),
   listSSHKeys: () => client.config.ssh.listKeys(),


### PR DESCRIPTION
## Summary

- Remove the enable/disable toggle for host access from the web landing page
- Host access configuration should only be controlled on the host itself (via CLI flags like `--host-access`), not remotely through the web interface
- The HostSection now displays the current state as read-only, with guidance on how to enable via CLI flag when disabled

## Changes

- **Backend**: Remove `updateHostAccess` endpoint from router
- **Frontend**: Remove `updateHostAccess` API method and toggle mutation
- **UI**: Simplify `HostSection` to be display-only, showing CLI instructions when disabled