### PR TITLE
Remove unused host.updateAccess from client APIs

### DIFF
--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -187,7 +187,6 @@ function createClient() {
     info: () => Promise<InfoResponse>
     host: {
       info: () => Promise<HostInfo>
-      updateAccess: (input: { enabled: boolean }) => Promise<HostInfo>
     }
     config: {
       credentials: {
@@ -268,7 +267,6 @@ export const api = {
     client.sessions.recordAccess({ workspaceName, sessionId, agentType }),
   getInfo: () => client.info(),
   getHostInfo: () => client.host.info(),
-  updateHostAccess: (enabled: boolean) => client.host.updateAccess({ enabled }),
   getCredentials: () => client.config.credentials.get(),
   updateCredentials: (data: Credentials) => client.config.credentials.update(data),
   getScripts: () => client.config.scripts.get(),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -101,7 +101,6 @@ const client = createORPCClient<{
   info: () => Promise<InfoResponse>
   host: {
     info: () => Promise<HostInfo>
-    updateAccess: (input: { enabled: boolean }) => Promise<HostInfo>
   }
   config: {
     credentials: {


### PR DESCRIPTION
## Summary
- Remove `host.updateAccess` endpoint from web and mobile client API definitions
- Host enable/disable is only controllable by the host itself via `--host-access` flag

The backend never implemented this endpoint - it was defined but unused in client types.