### PR TITLE
Fix send button growing with textarea in chat

### DIFF
--- a/mobile/src/screens/SessionChatScreen.tsx
+++ b/mobile/src/screens/SessionChatScreen.tsx
@@ -928,6 +928,7 @@ const styles = StyleSheet.create({
   },
   inputContainer: {
     flexDirection: 'row',
+    alignItems: 'flex-end',
     padding: 8,
     borderTopWidth: 1,
     borderTopColor: '#1c1c1e',
@@ -947,6 +948,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#0a84ff',
     borderRadius: 20,
     paddingHorizontal: 16,
+    height: 40,
     justifyContent: 'center',
   },
   sendBtnDisabled: {
@@ -961,6 +963,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#ff3b30',
     borderRadius: 20,
     paddingHorizontal: 16,
+    height: 40,
     justifyContent: 'center',
   },
   stopBtnText: {


### PR DESCRIPTION
## Summary
- Send/Stop button no longer stretches when the multiline textarea grows
- Button stays fixed at bottom of input container

## Test plan
- [ ] Open chat, type multiline message
- [ ] Verify send button stays same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)