### PR TITLE
Show thinking dots while agent is streaming

### DIFF
--- a/mobile/src/screens/SessionChatScreen.tsx
+++ b/mobile/src/screens/SessionChatScreen.tsx
@@ -239,12 +239,10 @@ function ThinkingDots() {
 }
 
 function StreamingBubble({ parts }: { parts: MessagePart[] }) {
-  const hasContent = parts.some(p => p.content.length > 0)
-
   return (
     <View style={styles.partsContainer}>
       {renderPartsWithPairedTools(parts)}
-      {!hasContent && <ThinkingDots />}
+      <ThinkingDots />
     </View>
   )
 }

--- a/web/src/components/Chat.tsx
+++ b/web/src/components/Chat.tsx
@@ -224,12 +224,10 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 }
 
 function StreamingMessage({ parts }: { parts: ChatMessagePart[] }) {
-  const hasContent = parts.some(p => p.content.length > 0)
-
   return (
     <div className="space-y-3">
       {renderPartsWithPairedTools(parts)}
-      <div className={cn("flex gap-1 transition-opacity duration-150", hasContent ? "opacity-0 h-0 overflow-hidden" : "opacity-100")}>
+      <div className="flex gap-1">
         <span className="w-2 h-2 bg-muted-foreground/40 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
         <span className="w-2 h-2 bg-muted-foreground/40 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
         <span className="w-2 h-2 bg-muted-foreground/40 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />


### PR DESCRIPTION
## Summary
- Thinking dots now stay visible at the bottom while streaming
- Users can tell the agent is still working even after content appears

## Test plan
- [ ] Send a message in chat
- [ ] Verify thinking dots appear
- [ ] Verify dots remain visible even after tool calls/text appear
- [ ] Verify dots disappear when response is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)