### PR TITLE
Consolidate duplicate utility functions

### DIFF
--- a/src/client/docker-proxy.ts
+++ b/src/client/docker-proxy.ts
@@ -1,9 +1,7 @@
 import type { Socket } from 'bun';
+import { PortForward, parsePortForward, formatPortForwards } from './port-forward';
 
-export interface PortForward {
-  localPort: number;
-  remotePort: number;
-}
+export { PortForward, parsePortForward, formatPortForwards };
 
 export interface DockerProxyOptions {
   containerIp: string;
@@ -100,24 +98,4 @@ export async function startDockerProxy(options: DockerProxyOptions): Promise<() 
       server.stop();
     }
   };
-}
-
-export function formatPortForwards(forwards: PortForward[]): string {
-  return forwards
-    .map((f) =>
-      f.localPort === f.remotePort ? String(f.localPort) : `${f.localPort}:${f.remotePort}`
-    )
-    .join(', ');
-}
-
-export function parsePortForward(spec: string): PortForward {
-  if (spec.includes(':')) {
-    const [local, remote] = spec.split(':');
-    return {
-      localPort: parseInt(local, 10),
-      remotePort: parseInt(remote, 10),
-    };
-  }
-  const port = parseInt(spec, 10);
-  return { localPort: port, remotePort: port };
 }

--- a/src/client/port-forward.ts
+++ b/src/client/port-forward.ts
@@ -1,0 +1,24 @@
+export interface PortForward {
+  localPort: number;
+  remotePort: number;
+}
+
+export function parsePortForward(spec: string): PortForward {
+  if (spec.includes(':')) {
+    const [local, remote] = spec.split(':');
+    return {
+      localPort: parseInt(local, 10),
+      remotePort: parseInt(remote, 10),
+    };
+  }
+  const port = parseInt(spec, 10);
+  return { localPort: port, remotePort: port };
+}
+
+export function formatPortForwards(forwards: PortForward[]): string {
+  return forwards
+    .map((f) =>
+      f.localPort === f.remotePort ? String(f.localPort) : `${f.localPort}:${f.remotePort}`
+    )
+    .join(', ');
+}

--- a/src/client/proxy.ts
+++ b/src/client/proxy.ts
@@ -1,9 +1,7 @@
 import { spawn } from 'child_process';
+import { PortForward, parsePortForward, formatPortForwards } from './port-forward';
 
-export interface PortForward {
-  localPort: number;
-  remotePort: number;
-}
+export { PortForward, parsePortForward, formatPortForwards };
 
 export interface ProxyOptions {
   worker: string;
@@ -13,18 +11,6 @@ export interface ProxyOptions {
   onConnect?: () => void;
   onDisconnect?: (code: number) => void;
   onError?: (error: Error) => void;
-}
-
-export function parsePortForward(spec: string): PortForward {
-  if (spec.includes(':')) {
-    const [local, remote] = spec.split(':');
-    return {
-      localPort: parseInt(local, 10),
-      remotePort: parseInt(remote, 10),
-    };
-  }
-  const port = parseInt(spec, 10);
-  return { localPort: port, remotePort: port };
 }
 
 export async function startProxy(options: ProxyOptions): Promise<void> {
@@ -125,12 +111,4 @@ export async function startProxy(options: ProxyOptions): Promise<void> {
       }
     });
   });
-}
-
-export function formatPortForwards(forwards: PortForward[]): string {
-  return forwards
-    .map((f) =>
-      f.localPort === f.remotePort ? String(f.localPort) : `${f.localPort}:${f.remotePort}`
-    )
-    .join(', ');
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,9 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { DEFAULT_CONFIG_DIR, CONFIG_FILE, type AgentConfig } from '../shared/types';
 import { DEFAULT_AGENT_PORT } from '../shared/constants';
+import { expandPath } from '../shared/path-utils';
+
+export { expandPath };
 
 export function getConfigDir(configDir?: string): string {
   return configDir || process.env.WS_CONFIG_DIR || DEFAULT_CONFIG_DIR;
@@ -90,11 +93,4 @@ export async function saveAgentConfig(config: AgentConfig, configDir?: string): 
   await ensureConfigDir(dir);
   const configPath = path.join(dir, CONFIG_FILE);
   await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8');
-}
-
-export function expandPath(filePath: string): string {
-  if (filePath.startsWith('~/')) {
-    return path.join(process.env.HOME || '', filePath.slice(2));
-  }
-  return filePath;
 }

--- a/src/shared/path-utils.ts
+++ b/src/shared/path-utils.ts
@@ -1,0 +1,9 @@
+import { homedir } from 'os';
+import { join } from 'path';
+
+export function expandPath(filePath: string): string {
+  if (filePath.startsWith('~/')) {
+    return join(homedir(), filePath.slice(2));
+  }
+  return filePath;
+}

--- a/src/ssh/sync.ts
+++ b/src/ssh/sync.ts
@@ -1,8 +1,7 @@
 import { readFile } from 'fs/promises';
-import { join } from 'path';
-import { homedir } from 'os';
 import type { SSHSettings, SSHKeyConfig } from '../shared/types';
 import { discoverSSHKeys, readPublicKey } from './discovery';
+import { expandPath } from '../shared/path-utils';
 
 export interface SSHSyncResult {
   authorizedKeys: string[];
@@ -94,11 +93,4 @@ export async function collectCopyKeys(
   }
 
   return result;
-}
-
-function expandPath(filePath: string): string {
-  if (filePath.startsWith('~/')) {
-    return join(homedir(), filePath.slice(2));
-  }
-  return filePath;
 }


### PR DESCRIPTION
## Summary
Extract shared utilities to reduce code duplication flagged by the custom oxlint plugin:

- `src/client/port-forward.ts`: `parsePortForward`, `formatPortForwards`
  - Previously duplicated in `proxy.ts` and `docker-proxy.ts` (identical implementations)
  
- `src/shared/path-utils.ts`: `expandPath`
  - Previously duplicated in `config/loader.ts` and `ssh/sync.ts` (nearly identical)

Both original modules re-export the functions for backward compatibility.

## Not consolidated (different semantics)
- `extractContent` - one version joins ALL text parts, other finds FIRST only
- `runCommand` - different return types/signatures for different use cases
- `formatUptime` - mobile version is simpler (hours/minutes only)
- Mobile components (`AgentBadge`, `MessageBubble`) - different styling per screen

## Test plan
- [x] `bun run check` passes (lint + format + typecheck)
- [x] `bun run build:ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)