### PR TITLE
Run workspace init as workspace user to fix file ownership

### DIFF
--- a/perry/internal/src/commands/entrypoint.ts
+++ b/perry/internal/src/commands/entrypoint.ts
@@ -1,7 +1,7 @@
 import { addSshKeys } from "./add-ssh-key";
-import { runInit } from "./init";
 import { syncUserWithHost } from "./sync-user";
 import { ensureDockerd, monitorServices, startSshd, tailDockerdLogs, waitForDocker } from "../lib/services";
+import { runCommand } from "../lib/process";
 
 export const runEntrypoint = async () => {
   console.log("[entrypoint] Syncing user with host...");
@@ -19,9 +19,11 @@ export const runEntrypoint = async () => {
     process.exit(1);
     return;
   }
-  console.log("[entrypoint] Running workspace initialization...");
+  console.log("[entrypoint] Running workspace initialization as workspace user...");
   try {
-    await runInit();
+    await runCommand("sudo", ["-u", "workspace", "-E", "/usr/local/bin/workspace-internal", "init"], {
+      env: process.env,
+    });
   } catch (error) {
     console.log(`[entrypoint] Initialization failed (non-fatal): ${(error as Error).message}`);
     console.log("[entrypoint] SSH will still start - connect to debug the issue");


### PR DESCRIPTION
## Summary

- Fix file ownership issue where files created during workspace initialization (git clone, shell configs, LazyVim, dev tools) were owned by root instead of the workspace user

## Problem

The container entrypoint runs as root (required for `usermod`, `groupmod`, `dockerd`, `sshd`). While `syncUserWithHost()` runs first and does `chown -R` on `/home/workspace`, the `runInit()` function runs afterward as root, creating new files all owned by root.

## Solution

Instead of calling `runInit()` directly, spawn it as a subprocess running as the `workspace` user:

```typescript
await runCommand("sudo", ["-u", "workspace", "-E", "/usr/local/bin/workspace-internal", "init"], {
  env: process.env,
});
```

The `-E` flag preserves environment variables like `SSH_AUTH_SOCK`, `WORKSPACE_REPO_URL`, etc.