### PR TITLE
Use perrytest- prefix for test workspaces to avoid conflicts

### DIFF
--- a/test/helpers/agent.ts
+++ b/test/helpers/agent.ts
@@ -410,5 +410,5 @@ export async function startTestAgent(options: TestAgentOptions = {}): Promise<Te
 }
 
 export function generateTestWorkspaceName(): string {
-  return `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `perrytest-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }

--- a/test/setup/global.js
+++ b/test/setup/global.js
@@ -6,7 +6,7 @@ async function cleanupOrphanedResources() {
 
   try {
     const containers = execSync(
-      'docker ps -aq --filter "name=workspace-test-" 2>/dev/null || true',
+      'docker ps -aq --filter "name=workspace-perrytest-" 2>/dev/null || true',
       { encoding: 'utf-8' }
     ).trim();
 
@@ -16,7 +16,7 @@ async function cleanupOrphanedResources() {
     }
 
     const volumes = execSync(
-      'docker volume ls -q --filter "name=workspace-test-" 2>/dev/null || true',
+      'docker volume ls -q --filter "name=workspace-perrytest-" 2>/dev/null || true',
       { encoding: 'utf-8' }
     ).trim();
 


### PR DESCRIPTION
## Summary

- Changed test workspace prefix from `test-` to `perrytest-` to prevent accidental deletion of real workspaces during test cleanup

## Problem

Test cleanup in `test/setup/global.js` deletes all containers/volumes matching `workspace-test-*`. This could delete real user workspaces that happen to be named with a `test-` prefix.

## Changes

- `test/helpers/agent.ts`: `generateTestWorkspaceName()` now returns `perrytest-...` instead of `test-...`
- `test/setup/global.js`: Cleanup filters now match `workspace-perrytest-*`