### PR TITLE
Fix navigation after workspace delete and clone

### DIFF
--- a/mobile/src/screens/WorkspaceSettingsScreen.tsx
+++ b/mobile/src/screens/WorkspaceSettingsScreen.tsx
@@ -49,7 +49,7 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
     mutationFn: () => api.deleteWorkspace(name),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['workspaces'] })
-      navigation.navigate('Home')
+      navigation.popToTop()
     },
     onError: (err) => Alert.alert('Error', parseNetworkError(err)),
   })
@@ -67,7 +67,7 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
       setShowCloneModal(false)
       setCloneName('')
       Alert.alert('Success', `Workspace cloned as "${newWorkspace.name}"`)
-      navigation.navigate('Workspace', { name: newWorkspace.name })
+      navigation.replace('WorkspaceDetail', { name: newWorkspace.name })
     },
     onError: (err) => Alert.alert('Error', parseNetworkError(err)),
   })


### PR DESCRIPTION
## Summary
- Fix navigation stack issues after workspace delete and clone actions

## Changes
- **Delete**: Use `popToTop()` instead of `navigate('Home')` to properly pop back to Home screen instead of pushing a duplicate
- **Clone**: Use `replace()` instead of `navigate()` so the new workspace detail replaces the current settings screen, avoiding stale back navigation