### PR TITLE
Check version before running update command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -733,9 +733,31 @@ sshCmd
 program
   .command('update')
   .description('Update Perry to the latest version')
-  .action(async () => {
+  .option('-f, --force', 'Force update even if already on latest version')
+  .action(async (options) => {
+    const { fetchLatestVersion, compareVersions } = await import('./update-checker.js');
+    const currentVersion = pkg.version;
+
+    console.log(`Current version: ${currentVersion}`);
+    console.log('Checking for updates...');
+
+    const latestVersion = await fetchLatestVersion();
+
+    if (!latestVersion) {
+      console.error('Failed to fetch latest version. Please try again later.');
+      process.exit(1);
+    }
+
+    console.log(`Latest version: ${latestVersion}`);
+
+    if (compareVersions(currentVersion, latestVersion) <= 0 && !options.force) {
+      console.log('Already up to date.');
+      process.exit(0);
+    }
+
+    console.log(`Updating Perry from ${currentVersion} to ${latestVersion}...`);
+
     const { spawn } = await import('child_process');
-    console.log('Updating Perry...');
     const child = spawn(
       'bash',
       ['-c', 'curl -fsSL https://raw.githubusercontent.com/gricha/perry/main/install.sh | bash'],

--- a/src/update-checker.ts
+++ b/src/update-checker.ts
@@ -35,7 +35,7 @@ async function writeCache(cache: UpdateCache): Promise<void> {
   }
 }
 
-async function fetchLatestVersion(): Promise<string | null> {
+export async function fetchLatestVersion(): Promise<string | null> {
   try {
     const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`, {
       signal: AbortSignal.timeout(3000),
@@ -53,7 +53,7 @@ async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
-function compareVersions(current: string, latest: string): number {
+export function compareVersions(current: string, latest: string): number {
   const currentParts = current.split('.').map(Number);
   const latestParts = latest.split('.').map(Number);
 


### PR DESCRIPTION
## Summary
- `perry update` now checks if an update is needed before downloading
- Compares current binary version against latest GitHub release
- Exits early with "Already up to date." if no update is available
- Adds `--force` flag to force update when needed