### PR TITLE
Apply theme system to all mobile screens

### DIFF
--- a/mobile/src/screens/SetupScreen.tsx
+++ b/mobile/src/screens/SetupScreen.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { saveServerConfig, getDefaultPort, refreshClient, api } from '../lib/api'
+import { useTheme } from '../contexts/ThemeContext'
 
 const SETUP_GUIDE_URL = 'https://gricha.github.io/perry/docs/introduction'
 
@@ -23,6 +24,7 @@ interface SetupScreenProps {
 
 export function SetupScreen({ onComplete }: SetupScreenProps) {
   const insets = useSafeAreaInsets()
+  const { colors } = useTheme()
   const [host, setHost] = useState('')
   const [port, setPort] = useState(String(getDefaultPort()))
   const [isConnecting, setIsConnecting] = useState(false)
@@ -67,10 +69,10 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
 
   return (
     <KeyboardAvoidingView
-      style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+      style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom, backgroundColor: colors.background }]}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView 
+      <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
@@ -80,33 +82,33 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
               source={require('../../assets/icon.png')}
               style={styles.logoImage}
             />
-            <Text style={styles.logo}>Perry</Text>
-            <Text style={styles.tagline} testID="tagline">Isolated, self-hosted workspaces{'\n'}accessible over Tailscale</Text>
+            <Text style={[styles.logo, { color: colors.text }]}>Perry</Text>
+            <Text style={[styles.tagline, { color: colors.textMuted }]} testID="tagline">Isolated, self-hosted workspaces{'\n'}accessible over Tailscale</Text>
           </View>
 
-          <View style={styles.divider} />
+          <View style={[styles.divider, { backgroundColor: colors.surfaceSecondary }]} />
 
-          <TouchableOpacity style={styles.setupGuideCard} onPress={handleSetupGuide}>
+          <TouchableOpacity style={[styles.setupGuideCard, { backgroundColor: colors.surface }]} onPress={handleSetupGuide}>
             <View style={styles.setupGuideContent}>
-              <Text style={styles.setupGuideTitle}>Setup Guide</Text>
-              <Text style={styles.setupGuideSubtitle}>New to Perry? Learn how to set up your server</Text>
+              <Text style={[styles.setupGuideTitle, { color: colors.accent }]}>Setup Guide</Text>
+              <Text style={[styles.setupGuideSubtitle, { color: colors.textMuted }]}>New to Perry? Learn how to set up your server</Text>
             </View>
-            <Text style={styles.setupGuideArrow}>→</Text>
+            <Text style={[styles.setupGuideArrow, { color: colors.accent }]}>→</Text>
           </TouchableOpacity>
 
-          <View style={styles.divider} />
+          <View style={[styles.divider, { backgroundColor: colors.surfaceSecondary }]} />
 
           <View style={styles.form}>
-            <Text style={styles.formHeader}>Already have a server?</Text>
-            
+            <Text style={[styles.formHeader, { color: colors.textMuted }]}>Already have a server?</Text>
+
             <View style={styles.inputGroup}>
-              <Text style={styles.label}>Server Hostname</Text>
+              <Text style={[styles.label, { color: colors.text }]}>Server Hostname</Text>
               <TextInput
-                style={styles.input}
+                style={[styles.input, { backgroundColor: colors.surface, color: colors.text }]}
                 value={host}
                 onChangeText={setHost}
                 placeholder="my-server.tailnet.ts.net"
-                placeholderTextColor="#666"
+                placeholderTextColor={colors.textMuted}
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"
@@ -115,34 +117,34 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
             </View>
 
             <View style={styles.inputGroup}>
-              <Text style={styles.label}>Port</Text>
+              <Text style={[styles.label, { color: colors.text }]}>Port</Text>
               <TextInput
-                style={styles.input}
+                style={[styles.input, { backgroundColor: colors.surface, color: colors.text }]}
                 value={port}
                 onChangeText={setPort}
                 placeholder="7391"
-                placeholderTextColor="#666"
+                placeholderTextColor={colors.textMuted}
                 keyboardType="number-pad"
                 testID="port-input"
               />
             </View>
 
             {error && (
-              <View style={styles.errorContainer}>
-                <Text style={styles.errorText}>{error}</Text>
+              <View style={[styles.errorContainer, { backgroundColor: `${colors.error}26` }]}>
+                <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>
               </View>
             )}
 
             <TouchableOpacity
-              style={[styles.button, isConnecting && styles.buttonDisabled]}
+              style={[styles.button, { backgroundColor: colors.accent }, isConnecting && styles.buttonDisabled]}
               onPress={handleConnect}
               disabled={isConnecting}
               testID="connect-button"
             >
               {isConnecting ? (
-                <ActivityIndicator size="small" color="#fff" />
+                <ActivityIndicator size="small" color={colors.accentText} />
               ) : (
-                <Text style={styles.buttonText}>Connect</Text>
+                <Text style={[styles.buttonText, { color: colors.accentText }]}>Connect</Text>
               )}
             </TouchableOpacity>
           </View>

--- a/mobile/src/screens/TerminalScreen.tsx
+++ b/mobile/src/screens/TerminalScreen.tsx
@@ -15,9 +15,11 @@ import { useQuery } from '@tanstack/react-query'
 import { api, getTerminalUrl, HOST_WORKSPACE_NAME } from '../lib/api'
 import { ExtraKeysBar } from '../components/ExtraKeysBar'
 import { TERMINAL_HTML } from '../lib/terminal-html'
+import { useTheme } from '../contexts/ThemeContext'
 
 export function TerminalScreen({ route, navigation }: any) {
   const insets = useSafeAreaInsets()
+  const { colors } = useTheme()
   const { name } = route.params
   const webViewRef = useRef<WebView>(null)
   const [connected, setConnected] = useState(false)
@@ -112,31 +114,31 @@ export function TerminalScreen({ route, navigation }: any) {
 
   if (!isRunning) {
     return (
-      <View style={[styles.container, { paddingTop: insets.top }]}>
-        <View style={styles.header}>
+      <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
           <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-            <Text style={styles.backBtnText}>‹</Text>
+            <Text style={[styles.backBtnText, { color: colors.accent }]}>‹</Text>
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>Terminal</Text>
+          <Text style={[styles.headerTitle, { color: colors.text }]}>Terminal</Text>
           <View style={styles.placeholder} />
         </View>
         <View style={styles.notRunning}>
-          <Text style={styles.notRunningText}>Workspace is not running</Text>
-          <Text style={styles.notRunningSubtext}>Start it to access the terminal</Text>
+          <Text style={[styles.notRunningText, { color: colors.textMuted }]}>Workspace is not running</Text>
+          <Text style={[styles.notRunningSubtext, { color: colors.textMuted }]}>Start it to access the terminal</Text>
         </View>
       </View>
     )
   }
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
-      <View style={styles.header}>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-          <Text style={styles.backBtnText}>‹</Text>
+          <Text style={[styles.backBtnText, { color: colors.accent }]}>‹</Text>
         </TouchableOpacity>
         <View style={styles.headerCenter}>
-          <Text style={styles.headerTitle}>Terminal</Text>
-          <View style={[styles.connectionDot, { backgroundColor: connected ? '#34c759' : '#636366' }]} />
+          <Text style={[styles.headerTitle, { color: colors.text }]}>Terminal</Text>
+          <View style={[styles.connectionDot, { backgroundColor: connected ? colors.success : colors.textMuted }]} />
         </View>
         <View style={styles.placeholder} />
       </View>
@@ -154,8 +156,8 @@ export function TerminalScreen({ route, navigation }: any) {
       >
         {loading && (
           <View style={styles.loadingOverlay}>
-            <ActivityIndicator size="large" color="#0a84ff" />
-            <Text style={styles.loadingText}>Loading terminal...</Text>
+            <ActivityIndicator size="large" color={colors.accent} />
+            <Text style={[styles.loadingText, { color: colors.textMuted }]}>Loading terminal...</Text>
           </View>
         )}
         <WebView

--- a/mobile/src/screens/WorkspaceDetailScreen.tsx
+++ b/mobile/src/screens/WorkspaceDetailScreen.tsx
@@ -12,6 +12,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useFocusEffect } from '@react-navigation/native'
 import { useQuery } from '@tanstack/react-query'
 import { api, SessionInfo, AgentType, HOST_WORKSPACE_NAME } from '../lib/api'
+import { useTheme } from '../contexts/ThemeContext'
+import { ThemeColors } from '../lib/themes'
 
 type DateGroup = 'Today' | 'Yesterday' | 'This Week' | 'Older'
 
@@ -50,13 +52,13 @@ function AgentBadge({ type }: { type: AgentType }) {
     opencode: 'OC',
     codex: 'CX',
   }
-  const colors: Record<AgentType, string> = {
+  const badgeColors: Record<AgentType, string> = {
     'claude-code': '#8b5cf6',
     opencode: '#22c55e',
     codex: '#f59e0b',
   }
   return (
-    <View style={[styles.agentBadge, { backgroundColor: colors[type] }]}>
+    <View style={[styles.agentBadge, { backgroundColor: badgeColors[type] }]}>
       <Text style={styles.agentBadgeText}>{labels[type]}</Text>
     </View>
   )
@@ -65,9 +67,11 @@ function AgentBadge({ type }: { type: AgentType }) {
 function SessionRow({
   session,
   onPress,
+  colors,
 }: {
   session: SessionInfo
   onPress: () => void
+  colors: ThemeColors
 }) {
   const timeAgo = useMemo(() => {
     const date = new Date(session.lastActivity)
@@ -82,32 +86,33 @@ function SessionRow({
   }, [session.lastActivity])
 
   return (
-    <TouchableOpacity style={styles.sessionRow} onPress={onPress}>
+    <TouchableOpacity style={[styles.sessionRow, { borderBottomColor: colors.border }]} onPress={onPress}>
       <AgentBadge type={session.agentType} />
       <View style={styles.sessionContent}>
-        <Text style={styles.sessionName} numberOfLines={1}>
+        <Text style={[styles.sessionName, { color: colors.text }]} numberOfLines={1}>
           {session.name || session.firstPrompt || 'Empty session'}
         </Text>
-        <Text style={styles.sessionMeta}>
+        <Text style={[styles.sessionMeta, { color: colors.textMuted }]}>
           {session.messageCount} messages • {session.projectPath.split('/').pop()}
         </Text>
       </View>
-      <Text style={styles.sessionTime}>{timeAgo}</Text>
-      <Text style={styles.sessionChevron}>›</Text>
+      <Text style={[styles.sessionTime, { color: colors.textMuted }]}>{timeAgo}</Text>
+      <Text style={[styles.sessionChevron, { color: colors.textMuted }]}>›</Text>
     </TouchableOpacity>
   )
 }
 
-function DateGroupHeader({ title }: { title: string }) {
+function DateGroupHeader({ title, colors }: { title: string; colors: ThemeColors }) {
   return (
     <View style={styles.dateGroupHeader}>
-      <Text style={styles.dateGroupTitle}>{title}</Text>
+      <Text style={[styles.dateGroupTitle, { color: colors.textMuted }]}>{title}</Text>
     </View>
   )
 }
 
 export function WorkspaceDetailScreen({ route, navigation }: any) {
   const insets = useSafeAreaInsets()
+  const { colors } = useTheme()
   const { name } = route.params
   const [agentFilter, setAgentFilter] = useState<AgentType | undefined>(undefined)
   const [showAgentPicker, setShowAgentPicker] = useState(false)
@@ -188,18 +193,18 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
   }
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
-      <View style={styles.header}>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-          <Text style={styles.backBtnText}>‹</Text>
+          <Text style={[styles.backBtnText, { color: colors.accent }]}>‹</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.headerCenter}
           onPress={() => setShowWorkspacePicker(!showWorkspacePicker)}
         >
-          <Text style={[styles.headerTitle, isHost && styles.hostHeaderTitle]} numberOfLines={1}>{displayName}</Text>
-          <View style={[styles.statusIndicator, { backgroundColor: isHost ? '#f59e0b' : (isRunning ? '#34c759' : isCreating ? '#ff9f0a' : '#636366') }]} />
-          <Text style={styles.headerChevron}>▼</Text>
+          <Text style={[styles.headerTitle, { color: colors.text }, isHost && styles.hostHeaderTitle]} numberOfLines={1}>{displayName}</Text>
+          <View style={[styles.statusIndicator, { backgroundColor: isHost ? colors.warning : (isRunning ? colors.success : isCreating ? colors.warning : colors.textMuted) }]} />
+          <Text style={[styles.headerChevron, { color: colors.textMuted }]}>▼</Text>
         </TouchableOpacity>
         {isHost ? (
           <View style={styles.settingsBtn} />
@@ -208,57 +213,57 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
             onPress={() => navigation.navigate('WorkspaceSettings', { name })}
             style={styles.settingsBtn}
           >
-            <Text style={styles.settingsIcon}>⚙</Text>
+            <Text style={[styles.settingsIcon, { color: colors.textMuted }]}>⚙</Text>
           </TouchableOpacity>
         )}
       </View>
 
-      <View style={styles.actionBar}>
+      <View style={[styles.actionBar, { borderBottomColor: colors.border }]}>
         <TouchableOpacity
-          style={styles.filterBtn}
+          style={[styles.filterBtn, { backgroundColor: colors.surface }]}
           onPress={() => setShowAgentPicker(!showAgentPicker)}
         >
-          <Text style={styles.filterBtnText}>
+          <Text style={[styles.filterBtnText, { color: colors.text }]}>
             {agentLabels[agentFilter || 'all']}
           </Text>
-          <Text style={styles.filterBtnArrow}>▼</Text>
+          <Text style={[styles.filterBtnArrow, { color: colors.textMuted }]}>▼</Text>
         </TouchableOpacity>
 
         <View style={styles.actionButtons}>
           <TouchableOpacity
-            style={styles.terminalBtn}
+            style={[styles.terminalBtn, { backgroundColor: colors.surface }]}
             onPress={() => navigation.navigate('Terminal', { name })}
             disabled={!isRunning}
             testID="terminal-button"
           >
-            <Text style={[styles.terminalBtnText, !isRunning && styles.disabledText]}>Terminal</Text>
+            <Text style={[styles.terminalBtnText, { color: colors.text }, !isRunning && styles.disabledText]}>Terminal</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.newChatBtn}
+            style={[styles.newChatBtn, { backgroundColor: colors.accent }]}
             onPress={() => setShowNewChatPicker(!showNewChatPicker)}
             disabled={!isRunning}
             testID="new-chat-button"
           >
-            <Text style={[styles.newChatBtnText, !isRunning && styles.disabledText]}>New Chat ▼</Text>
+            <Text style={[styles.newChatBtnText, { color: colors.accentText }, !isRunning && styles.disabledText]}>New Chat ▼</Text>
           </TouchableOpacity>
         </View>
       </View>
 
       {showAgentPicker && (
-        <View style={styles.agentPicker}>
+        <View style={[styles.agentPicker, { backgroundColor: colors.surface }]}>
           {(['all', 'claude-code', 'opencode', 'codex'] as const).map((type) => (
             <TouchableOpacity
               key={type}
               style={[
                 styles.agentPickerItem,
-                (type === 'all' ? !agentFilter : agentFilter === type) && styles.agentPickerItemActive,
+                (type === 'all' ? !agentFilter : agentFilter === type) && [styles.agentPickerItemActive, { backgroundColor: colors.surfaceSecondary }],
               ]}
               onPress={() => {
                 setAgentFilter(type === 'all' ? undefined : type as AgentType)
                 setShowAgentPicker(false)
               }}
             >
-              <Text style={styles.agentPickerText}>{agentLabels[type]}</Text>
+              <Text style={[styles.agentPickerText, { color: colors.text }]}>{agentLabels[type]}</Text>
             </TouchableOpacity>
           ))}
         </View>
@@ -267,8 +272,8 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
       {showNewChatPicker && (
         <View style={styles.newChatPickerOverlay}>
           <TouchableOpacity style={styles.newChatPickerBackdrop} onPress={() => setShowNewChatPicker(false)} />
-          <View style={styles.newChatPicker}>
-            <Text style={styles.newChatPickerTitle}>Start chat with</Text>
+          <View style={[styles.newChatPicker, { backgroundColor: colors.surfaceSecondary }]}>
+            <Text style={[styles.newChatPickerTitle, { color: colors.textMuted }]}>Start chat with</Text>
             {(['claude-code', 'opencode', 'codex'] as const).map((type) => (
               <TouchableOpacity
                 key={type}
@@ -282,7 +287,7 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
                 <View style={[styles.agentBadgeLarge, { backgroundColor: type === 'claude-code' ? '#8b5cf6' : type === 'opencode' ? '#22c55e' : '#f59e0b' }]}>
                   <Text style={styles.agentBadgeLargeText}>{type === 'claude-code' ? 'CC' : type === 'opencode' ? 'OC' : 'CX'}</Text>
                 </View>
-                <Text style={styles.newChatPickerItemText}>{agentLabels[type]}</Text>
+                <Text style={[styles.newChatPickerItemText, { color: colors.text }]}>{agentLabels[type]}</Text>
               </TouchableOpacity>
             ))}
           </View>
@@ -292,12 +297,12 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
       {showWorkspacePicker && (
         <View style={styles.workspacePickerOverlay}>
           <TouchableOpacity style={styles.workspacePickerBackdrop} onPress={() => setShowWorkspacePicker(false)} />
-          <View style={styles.workspacePicker}>
-            <Text style={styles.workspacePickerTitle}>Switch workspace</Text>
+          <View style={[styles.workspacePicker, { backgroundColor: colors.surfaceSecondary }]}>
+            <Text style={[styles.workspacePickerTitle, { color: colors.textMuted }]}>Switch workspace</Text>
             {allWorkspaces?.map((ws) => (
               <TouchableOpacity
                 key={ws.name}
-                style={[styles.workspacePickerItem, ws.name === name && styles.workspacePickerItemActive]}
+                style={[styles.workspacePickerItem, ws.name === name && [styles.workspacePickerItemActive, { backgroundColor: colors.surface }]]}
                 onPress={() => {
                   setShowWorkspacePicker(false)
                   if (ws.name !== name) {
@@ -305,9 +310,9 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
                   }
                 }}
               >
-                <View style={[styles.workspaceStatusDot, { backgroundColor: ws.status === 'running' ? '#34c759' : ws.status === 'creating' ? '#ff9f0a' : '#636366' }]} />
-                <Text style={[styles.workspacePickerItemText, ws.name === name && styles.workspacePickerItemTextActive]}>{ws.name}</Text>
-                {ws.name === name && <Text style={styles.workspaceCheckmark}>✓</Text>}
+                <View style={[styles.workspaceStatusDot, { backgroundColor: ws.status === 'running' ? colors.success : ws.status === 'creating' ? colors.warning : colors.textMuted }]} />
+                <Text style={[styles.workspacePickerItemText, { color: colors.text }, ws.name === name && styles.workspacePickerItemTextActive]}>{ws.name}</Text>
+                {ws.name === name && <Text style={[styles.workspaceCheckmark, { color: colors.accent }]}>✓</Text>}
               </TouchableOpacity>
             ))}
             {!isHost && (
@@ -318,8 +323,8 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
                   navigation.replace('WorkspaceDetail', { name: HOST_WORKSPACE_NAME })
                 }}
               >
-                <View style={[styles.workspaceStatusDot, { backgroundColor: '#f59e0b' }]} />
-                <Text style={styles.workspacePickerItemText}>Host Machine</Text>
+                <View style={[styles.workspaceStatusDot, { backgroundColor: colors.warning }]} />
+                <Text style={[styles.workspacePickerItemText, { color: colors.text }]}>Host Machine</Text>
               </TouchableOpacity>
             )}
           </View>
@@ -327,8 +332,8 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
       )}
 
       {isHost && (
-        <View style={styles.hostWarningBanner}>
-          <Text style={styles.hostWarningText}>
+        <View style={[styles.hostWarningBanner, { borderBottomColor: `${colors.warning}33` }]}>
+          <Text style={[styles.hostWarningText, { color: colors.warning }]}>
             Commands run directly on your machine without isolation
           </Text>
         </View>
@@ -336,29 +341,29 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
 
       {workspaceLoading && !isHost ? (
         <View style={styles.center}>
-          <ActivityIndicator size="large" color="#0a84ff" />
+          <ActivityIndicator size="large" color={colors.accent} />
         </View>
       ) : !isRunning && !isHost ? (
         isCreating ? (
           <View style={styles.notRunning}>
-            <ActivityIndicator size="large" color="#ff9f0a" style={{ marginBottom: 16 }} />
-            <Text style={styles.notRunningText}>Workspace is starting</Text>
-            <Text style={styles.notRunningSubtext}>Please wait while the container starts up</Text>
+            <ActivityIndicator size="large" color={colors.warning} style={{ marginBottom: 16 }} />
+            <Text style={[styles.notRunningText, { color: colors.textMuted }]}>Workspace is starting</Text>
+            <Text style={[styles.notRunningSubtext, { color: colors.textMuted }]}>Please wait while the container starts up</Text>
           </View>
         ) : (
           <View style={styles.notRunning}>
-            <Text style={styles.notRunningText}>Workspace is not running</Text>
-            <Text style={styles.notRunningSubtext}>Start it from settings to view sessions</Text>
+            <Text style={[styles.notRunningText, { color: colors.textMuted }]}>Workspace is not running</Text>
+            <Text style={[styles.notRunningSubtext, { color: colors.textMuted }]}>Start it from settings to view sessions</Text>
           </View>
         )
       ) : sessionsLoading ? (
         <View style={styles.center}>
-          <ActivityIndicator size="large" color="#0a84ff" />
+          <ActivityIndicator size="large" color={colors.accent} />
         </View>
       ) : flatData.length === 0 ? (
         <View style={styles.empty}>
-          <Text style={styles.emptyText}>No sessions yet</Text>
-          <Text style={styles.emptySubtext}>Start a new chat to create one</Text>
+          <Text style={[styles.emptyText, { color: colors.textMuted }]}>No sessions yet</Text>
+          <Text style={[styles.emptySubtext, { color: colors.textMuted }]}>Start a new chat to create one</Text>
         </View>
       ) : (
         <FlatList
@@ -366,11 +371,12 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
           keyExtractor={(item) => item.type === 'header' ? `header-${item.title}` : `session-${item.session.id}`}
           renderItem={({ item }) => {
             if (item.type === 'header') {
-              return <DateGroupHeader title={item.title} />
+              return <DateGroupHeader title={item.title} colors={colors} />
             }
             return (
               <SessionRow
                 session={item.session}
+                colors={colors}
                 onPress={() => navigation.navigate('SessionChat', {
                   workspaceName: name,
                   sessionId: item.session.id,
@@ -385,7 +391,7 @@ export function WorkspaceDetailScreen({ route, navigation }: any) {
             <RefreshControl
               refreshing={isManualRefresh}
               onRefresh={handleManualRefresh}
-              tintColor="#fff"
+              tintColor={colors.text}
             />
           }
         />

--- a/mobile/src/screens/WorkspaceSettingsScreen.tsx
+++ b/mobile/src/screens/WorkspaceSettingsScreen.tsx
@@ -14,9 +14,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '../lib/api'
 import { parseNetworkError } from '../lib/network'
+import { useTheme } from '../contexts/ThemeContext'
 
 export function WorkspaceSettingsScreen({ route, navigation }: any) {
   const insets = useSafeAreaInsets()
+  const { colors } = useTheme()
   const { name } = route.params
   const queryClient = useQueryClient()
   const [showCloneModal, setShowCloneModal] = useState(false)
@@ -91,8 +93,8 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
 
   if (isLoading || !workspace) {
     return (
-      <View style={[styles.container, styles.center, { paddingTop: insets.top }]}>
-        <ActivityIndicator size="large" color="#0a84ff" />
+      <View style={[styles.container, styles.center, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.accent} />
       </View>
     )
   }
@@ -101,48 +103,48 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
   const isPending = startMutation.isPending || stopMutation.isPending || deleteMutation.isPending || syncMutation.isPending || cloneMutation.isPending
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
-      <View style={styles.header}>
+    <View style={[styles.container, { paddingTop: insets.top, backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
-          <Text style={styles.backBtnText}>‹</Text>
+          <Text style={[styles.backBtnText, { color: colors.accent }]}>‹</Text>
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>Settings</Text>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Settings</Text>
         <View style={styles.placeholder} />
       </View>
 
       <ScrollView contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 20 }]}>
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Workspace Details</Text>
-          <View style={styles.card}>
-            <View style={styles.infoRow}>
-              <Text style={styles.infoLabel}>Name</Text>
-              <Text style={styles.infoValue}>{workspace.name}</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textMuted }]}>Workspace Details</Text>
+          <View style={[styles.card, { backgroundColor: colors.surface }]}>
+            <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>
+              <Text style={[styles.infoLabel, { color: colors.text }]}>Name</Text>
+              <Text style={[styles.infoValue, { color: colors.textMuted }]}>{workspace.name}</Text>
             </View>
-            <View style={styles.infoRow}>
-              <Text style={styles.infoLabel}>Status</Text>
-              <Text style={[styles.infoValue, { color: isRunning ? '#34c759' : '#8e8e93' }]}>
+            <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>
+              <Text style={[styles.infoLabel, { color: colors.text }]}>Status</Text>
+              <Text style={[styles.infoValue, { color: isRunning ? colors.success : colors.textMuted }]}>
                 {workspace.status}
               </Text>
             </View>
-            <View style={styles.infoRow}>
-              <Text style={styles.infoLabel}>Container ID</Text>
-              <Text style={styles.infoValue} numberOfLines={1}>
+            <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>
+              <Text style={[styles.infoLabel, { color: colors.text }]}>Container ID</Text>
+              <Text style={[styles.infoValue, { color: colors.textMuted }]} numberOfLines={1}>
                 {workspace.containerId.slice(0, 12)}
               </Text>
             </View>
-            <View style={styles.infoRow}>
-              <Text style={styles.infoLabel}>SSH Port</Text>
-              <Text style={styles.infoValue}>{workspace.ports.ssh}</Text>
+            <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>
+              <Text style={[styles.infoLabel, { color: colors.text }]}>SSH Port</Text>
+              <Text style={[styles.infoValue, { color: colors.textMuted }]}>{workspace.ports.ssh}</Text>
             </View>
             {workspace.repo && (
-              <View style={styles.infoRow}>
-                <Text style={styles.infoLabel}>Repository</Text>
-                <Text style={styles.infoValue} numberOfLines={1}>{workspace.repo}</Text>
+              <View style={[styles.infoRow, { borderBottomColor: colors.surfaceSecondary }]}>
+                <Text style={[styles.infoLabel, { color: colors.text }]}>Repository</Text>
+                <Text style={[styles.infoValue, { color: colors.textMuted }]} numberOfLines={1}>{workspace.repo}</Text>
               </View>
             )}
             <View style={[styles.infoRow, { borderBottomWidth: 0 }]}>
-              <Text style={styles.infoLabel}>Created</Text>
-              <Text style={styles.infoValue}>
+              <Text style={[styles.infoLabel, { color: colors.text }]}>Created</Text>
+              <Text style={[styles.infoValue, { color: colors.textMuted }]}>
                 {new Date(workspace.created).toLocaleDateString()}
               </Text>
             </View>
@@ -150,27 +152,27 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Sync</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textMuted }]}>Sync</Text>
           <TouchableOpacity
-            style={[styles.actionBtn, !isRunning && styles.actionBtnDisabled]}
+            style={[styles.actionBtn, { backgroundColor: colors.accent }, !isRunning && [styles.actionBtnDisabled, { backgroundColor: colors.surfaceSecondary }]]}
             onPress={() => syncMutation.mutate()}
             disabled={!isRunning || isPending}
           >
             {syncMutation.isPending ? (
-              <ActivityIndicator size="small" color="#fff" />
+              <ActivityIndicator size="small" color={colors.accentText} />
             ) : (
-              <Text style={styles.actionBtnText}>Sync Credentials</Text>
+              <Text style={[styles.actionBtnText, { color: colors.accentText }]}>Sync Credentials</Text>
             )}
           </TouchableOpacity>
-          <Text style={styles.actionHint}>
+          <Text style={[styles.actionHint, { color: colors.textMuted }]}>
             Copy environment variables and credential files to workspace
           </Text>
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Clone</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textMuted }]}>Clone</Text>
           <TouchableOpacity
-            style={styles.actionBtn}
+            style={[styles.actionBtn, { backgroundColor: colors.accent }]}
             onPress={() => {
               setCloneName('')
               setShowCloneModal(true)
@@ -178,59 +180,59 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
             disabled={isPending}
           >
             {cloneMutation.isPending ? (
-              <ActivityIndicator size="small" color="#fff" />
+              <ActivityIndicator size="small" color={colors.accentText} />
             ) : (
-              <Text style={styles.actionBtnText}>Clone Workspace</Text>
+              <Text style={[styles.actionBtnText, { color: colors.accentText }]}>Clone Workspace</Text>
             )}
           </TouchableOpacity>
-          <Text style={styles.actionHint}>
+          <Text style={[styles.actionHint, { color: colors.textMuted }]}>
             Create a copy of this workspace with all its data
           </Text>
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Actions</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textMuted }]}>Actions</Text>
           {isRunning ? (
             <TouchableOpacity
-              style={[styles.actionBtn, styles.actionBtnWarning]}
+              style={[styles.actionBtn, { backgroundColor: colors.warning }]}
               onPress={() => stopMutation.mutate()}
               disabled={isPending}
             >
               {stopMutation.isPending ? (
-                <ActivityIndicator size="small" color="#fff" />
+                <ActivityIndicator size="small" color={colors.accentText} />
               ) : (
-                <Text style={styles.actionBtnText}>Stop Workspace</Text>
+                <Text style={[styles.actionBtnText, { color: colors.accentText }]}>Stop Workspace</Text>
               )}
             </TouchableOpacity>
           ) : (
             <TouchableOpacity
-              style={[styles.actionBtn, styles.actionBtnSuccess]}
+              style={[styles.actionBtn, { backgroundColor: colors.success }]}
               onPress={() => startMutation.mutate()}
               disabled={isPending}
             >
               {startMutation.isPending ? (
-                <ActivityIndicator size="small" color="#fff" />
+                <ActivityIndicator size="small" color={colors.accentText} />
               ) : (
-                <Text style={styles.actionBtnText}>Start Workspace</Text>
+                <Text style={[styles.actionBtnText, { color: colors.accentText }]}>Start Workspace</Text>
               )}
             </TouchableOpacity>
           )}
         </View>
 
         <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: '#ff3b30' }]}>Danger Zone</Text>
+          <Text style={[styles.sectionTitle, { color: colors.error }]}>Danger Zone</Text>
           <TouchableOpacity
-            style={[styles.actionBtn, styles.actionBtnDanger]}
+            style={[styles.actionBtn, { backgroundColor: colors.error }]}
             onPress={handleDelete}
             disabled={isPending}
           >
             {deleteMutation.isPending ? (
-              <ActivityIndicator size="small" color="#fff" />
+              <ActivityIndicator size="small" color={colors.accentText} />
             ) : (
-              <Text style={styles.actionBtnText}>Delete Workspace</Text>
+              <Text style={[styles.actionBtnText, { color: colors.accentText }]}>Delete Workspace</Text>
             )}
           </TouchableOpacity>
-          <Text style={styles.actionHint}>
+          <Text style={[styles.actionHint, { color: colors.textMuted }]}>
             This will permanently delete the workspace and all its data
           </Text>
         </View>
@@ -243,15 +245,15 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
         onRequestClose={() => setShowCloneModal(false)}
       >
         <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>Clone Workspace</Text>
-            <Text style={styles.modalDescription}>
+          <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>Clone Workspace</Text>
+            <Text style={[styles.modalDescription, { color: colors.textMuted }]}>
               Create a copy of "{name}" with all its data.
             </Text>
             <TextInput
-              style={styles.modalInput}
+              style={[styles.modalInput, { backgroundColor: colors.surfaceSecondary, color: colors.text }]}
               placeholder="New workspace name"
-              placeholderTextColor="#636366"
+              placeholderTextColor={colors.textMuted}
               value={cloneName}
               onChangeText={setCloneName}
               autoCapitalize="none"
@@ -259,21 +261,21 @@ export function WorkspaceSettingsScreen({ route, navigation }: any) {
             />
             <View style={styles.modalButtons}>
               <TouchableOpacity
-                style={[styles.modalBtn, styles.modalBtnCancel]}
+                style={[styles.modalBtn, styles.modalBtnCancel, { backgroundColor: colors.surfaceSecondary }]}
                 onPress={() => setShowCloneModal(false)}
                 disabled={cloneMutation.isPending}
               >
-                <Text style={styles.modalBtnCancelText}>Cancel</Text>
+                <Text style={[styles.modalBtnCancelText, { color: colors.text }]}>Cancel</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={[styles.modalBtn, styles.modalBtnConfirm, !cloneName.trim() && styles.modalBtnDisabled]}
+                style={[styles.modalBtn, styles.modalBtnConfirm, { backgroundColor: colors.accent }, !cloneName.trim() && [styles.modalBtnDisabled, { backgroundColor: colors.surfaceSecondary }]]}
                 onPress={handleClone}
                 disabled={!cloneName.trim() || cloneMutation.isPending}
               >
                 {cloneMutation.isPending ? (
-                  <ActivityIndicator size="small" color="#fff" />
+                  <ActivityIndicator size="small" color={colors.accentText} />
                 ) : (
-                  <Text style={styles.modalBtnConfirmText}>Clone</Text>
+                  <Text style={[styles.modalBtnConfirmText, { color: colors.accentText }]}>Clone</Text>
                 )}
               </TouchableOpacity>
             </View>


### PR DESCRIPTION
## Summary
- Apply theme colors to all 6 remaining mobile screens that were using hardcoded colors
- All screens now use `useTheme()` hook for consistent theming
- Enables users to switch themes and have it apply app-wide

## Screens Updated
- WorkspaceDetailScreen - sessions list, header, pickers
- SessionChatScreen - chat bubbles, tool displays, input area
- SetupScreen - form inputs, buttons, setup guide card
- WorkspaceSettingsScreen - settings cards, action buttons
- TerminalScreen - header, connection status
- SessionDetailScreen - message bubbles, meta bar

## Test plan
- [ ] Change theme in Settings
- [ ] Navigate through all screens and verify colors update
- [ ] Test light themes (Concrete, Blossom, Slate) as well as dark themes

🤖 Generated with [Claude Code](https://claude.ai/code)