### PR TITLE
Add worker version detection and on-demand update

### DIFF
--- a/src/worker/server.ts
+++ b/src/worker/server.ts
@@ -1,4 +1,5 @@
 import { sessionIndex, type IndexedSession, type Message } from './session-index';
+import pkg from '../../package.json' with { type: 'json' };
 
 const DEFAULT_PORT = 7392;
 
@@ -23,6 +24,7 @@ interface DeleteResponse {
 
 interface HealthResponse {
   status: 'ok';
+  version: string;
   sessionCount: number;
 }
 
@@ -42,6 +44,7 @@ export async function startWorkerServer(options: ServerOptions = {}): Promise<vo
       if (url.pathname === '/health' && req.method === 'GET') {
         const response: HealthResponse = {
           status: 'ok',
+          version: pkg.version,
           sessionCount: sessionIndex.list().length,
         };
         return Response.json(response);


### PR DESCRIPTION
## Summary

- Worker health endpoint now returns version info
- Workspace get API includes `workerVersion` for running workspaces
- New `updateWorker` API endpoint to update worker binary in a workspace
- `copyPerryWorker` prefers installed binary (`~/.perry/bin/perry`) over dist

## How it works

1. Worker `/health` endpoint returns `{ status: 'ok', version: '0.3.7', sessionCount: 5 }`
2. When fetching workspace details, API queries worker health and includes `workerVersion`
3. UI can compare `hostVersion` (from `/info`) with `workerVersion` 
4. If versions differ, UI shows "Update available" nudge with button
5. Button calls `workspaces.updateWorker({ name })` which:
   - Kills existing worker process
   - Copies new binary from host
   - Restarts worker server

## Test plan

- [ ] Start workspace, verify `GET /rpc/workspaces/get` returns `workerVersion`
- [ ] Verify worker health endpoint returns version: `curl http://<ip>:7392/health`
- [ ] Test updateWorker endpoint updates binary and restarts worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)