### PR TITLE
Add message deduplication to mobile chat screen

### DIFF
--- a/mobile/.maestro/config.yaml
+++ b/mobile/.maestro/config.yaml
@@ -5,3 +5,4 @@ flows:
   - workspace-actions.yaml
   - workspace-detail.yaml
   - session-filter.yaml
+  - session-chat.yaml

--- a/mobile/.maestro/session-chat.yaml
+++ b/mobile/.maestro/session-chat.yaml
@@ -1,0 +1,97 @@
+appId: com.subroutine.workspace
+---
+# Test: Session Chat Screen
+# Verifies the chat screen UI elements and basic interactions
+
+- launchApp:
+    clearState: true
+
+# Wait for app to fully load
+- extendedWaitUntil:
+    visible: "Workspaces"
+    timeout: 10000
+
+# Handle case when no workspaces exist
+- runFlow:
+    when:
+      visible: "No workspaces yet"
+    commands:
+      - assertVisible: "Tap + to create one"
+
+# Navigate to a workspace when they exist
+- runFlow:
+    when:
+      visible: "Details"
+    commands:
+      - tapOn: "Details"
+
+      # Should see workspace detail screen
+      - extendedWaitUntil:
+          visible: "Sessions"
+          timeout: 5000
+
+      # Tap on the new chat button
+      - tapOn:
+          id: "new-chat-button"
+
+      # Should see the agent picker
+      - extendedWaitUntil:
+          visible: "Claude Code"
+          timeout: 3000
+
+      # Select Claude Code agent
+      - tapOn:
+          id: "new-chat-claude-code"
+
+      # Should now be in the chat screen - verify input field exists
+      - extendedWaitUntil:
+          id: "chat-input"
+          timeout: 5000
+
+      # Verify send button exists and is initially disabled (no text)
+      - assertVisible:
+          id: "send-button"
+
+      # Type a test message
+      - tapOn:
+          id: "chat-input"
+      - inputText: "Hello, this is a test message"
+
+      # Handle connected vs disconnected states
+      - runFlow:
+          when:
+            visible:
+              id: "send-button"
+          commands:
+            # If connected, we can send the message
+            - tapOn:
+                id: "send-button"
+
+            # Message should appear as user message
+            - extendedWaitUntil:
+                id: "user-message"
+                timeout: 3000
+
+            # May see thinking dots if streaming
+            - runFlow:
+                when:
+                  visible:
+                    id: "thinking-dots"
+                commands:
+                  # If we see thinking dots, stop button should be visible
+                  - assertVisible:
+                      id: "stop-button"
+
+      # Handle error state (connection failed)
+      - runFlow:
+          when:
+            visible: "Connection error"
+          commands:
+            # This is expected when agent isn't running
+            - assertVisible: "Connection error"
+
+      # Navigate back
+      - tapOn: "‹"
+
+      # Should return to workspace detail
+      - assertVisible: "Sessions"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,7 +13,8 @@
     "test:e2e:settings": "maestro test .maestro/settings.yaml",
     "test:e2e:workspaces": "maestro test .maestro/workspaces.yaml",
     "test:e2e:sessions": "maestro test .maestro/session-filter.yaml",
-    "test:e2e:actions": "maestro test .maestro/workspace-actions.yaml"
+    "test:e2e:actions": "maestro test .maestro/workspace-actions.yaml",
+    "test:e2e:chat": "maestro test .maestro/session-chat.yaml"
   },
   "dependencies": {
     "@orpc/client": "^1.13.2",


### PR DESCRIPTION
## Summary
- Implement proper message ID-based deduplication in mobile app matching web UI behavior
- User messages deduplicate by `messageId` (or fallback to `timestamp:content`)
- Tool use/result messages deduplicate by `toolId`
- Track `currentMessageIdRef` during streaming and propagate to all parts
- Add Maestro e2e test for chat screen UI

## Test plan
- [ ] Open mobile app and start a chat session
- [ ] Send messages and verify no duplicates on reconnect
- [ ] Verify tool use/results don't duplicate when rejoining running session
- [ ] Run `bun run test:e2e:chat` (requires Maestro + simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)