### PR TITLE
Fix links opening twice in mobile chat

### DIFF
--- a/mobile/src/screens/SessionChatScreen.tsx
+++ b/mobile/src/screens/SessionChatScreen.tsx
@@ -253,7 +253,7 @@ function renderPartsWithPairedTools(parts: MessagePart[], colors: ThemeColors) {
         <View key={`text-${i}`} style={[styles.assistantBubble, { backgroundColor: colors.surface }]}>
           <Markdown
             style={getMarkdownStyles(colors)}
-            onLinkPress={(url) => { Linking.openURL(url).catch(() => {}); return true }}
+            onLinkPress={(url) => { Linking.openURL(url).catch(() => {}); return false }}
           >
             {trimmedContent}
           </Markdown>
@@ -295,7 +295,7 @@ function MessageBubble({ message, colors }: { message: ChatMessage; colors: Them
       <View style={[styles.userBubble, { backgroundColor: colors.accent }]} testID="user-message">
         <Markdown
           style={getMarkdownStyles(colors, true)}
-          onLinkPress={(url) => { Linking.openURL(url).catch(() => {}); return true }}
+          onLinkPress={(url) => { Linking.openURL(url).catch(() => {}); return false }}
         >
           {trimmedContent}
         </Markdown>
@@ -315,7 +315,7 @@ function MessageBubble({ message, colors }: { message: ChatMessage; colors: Them
     <View style={[styles.assistantBubble, { backgroundColor: colors.surface }]} testID="assistant-message">
       <Markdown
         style={getMarkdownStyles(colors)}
-        onLinkPress={(url) => { Linking.openURL(url).catch(() => {}); return true }}
+        onLinkPress={(url) => { Linking.openURL(url).catch(() => {}); return false }}
       >
         {trimmedContent}
       </Markdown>


### PR DESCRIPTION
## Summary
- Return `false` from `onLinkPress` to prevent double URL opening
- The library opens the URL by default when returning `true`, causing links to open twice

Fixes issue found by Sentry code review on #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)