### PR TITLE
Fix OpenCode adapter timeout and event handling

### DIFF
--- a/research/STASHED_ARCHITECTURE_REFACTOR.md
+++ b/research/STASHED_ARCHITECTURE_REFACTOR.md
@@ -1,0 +1,94 @@
+# Architecture Refactor Discussion (Stashed)
+
+## Current Problems
+
+### 1. State Scatter
+- Session state in `SessionManager`
+- Connection state in adapter (`status`, `port`, `agentSessionId`)
+- Port cache in module-level globals (`serverPorts`, `serverStarting`)
+
+### 2. No Connection Abstraction
+Each adapter implements its own connection logic. OpenCode adapter responsibilities:
+- Finding/starting OpenCode servers
+- Managing ports
+- Handling SSE streams
+- Message sending
+- Error handling
+
+Too many responsibilities in one class.
+
+### 3. SSE is Per-Message (not urgent)
+We create a new SSE connection for each message. Works, but inefficient.
+A persistent connection would be more robust.
+
+### 4. Reactive Not Proactive
+- Check if session exists when we try to use it
+- No health monitoring
+- No proactive reconnection
+
+## Proposed Architecture
+
+```
+                    ┌─────────────────┐
+                    │  SessionManager │
+                    │  (orchestrator) │
+                    └────────┬────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+     ┌────────▼────┐  ┌──────▼──────┐  ┌───▼────┐
+     │ Connection  │  │   Message   │  │ State  │
+     │   Manager   │  │    Queue    │  │  Store │
+     │ (health,    │  │ (ordering,  │  │ (disk, │
+     │  reconnect) │  │  retry)     │  │ memory)│
+     └─────────────┘  └─────────────┘  └────────┘
+              │
+     ┌────────▼────────┐
+     │  AgentAdapter   │
+     │  (protocol      │
+     │   translation)  │
+     └─────────────────┘
+```
+
+### Connection Manager
+- Owns connection lifecycle
+- State machine: DISCONNECTED → CONNECTING → CONNECTED → DISCONNECTED
+- Health checks (periodic ping)
+- Auto-reconnect with backoff
+- Emits connection state changes
+
+### Message Queue
+- Queues outgoing messages
+- Handles ordering
+- Retry logic (with idempotency considerations)
+- Circuit breaker for repeated failures
+
+### State Store
+- Unified session state
+- Disk persistence
+- Memory cache
+- Clear ownership of state
+
+### Agent Adapter (simplified)
+- Only handles protocol translation
+- Doesn't manage connections
+- Doesn't cache ports
+- Receives connection from ConnectionManager
+
+## Implementation Order
+
+1. Extract port management from adapter into ConnectionManager
+2. Add connection state machine
+3. Move session state into unified StateStore
+4. Add health monitoring
+5. (Optional) Persistent SSE connection
+
+## When to Do This
+
+When we see:
+- Multiple concurrent sessions causing issues
+- Long-lived connections needed
+- High message volume
+- More agent types being added
+
+Current pain level doesn't justify full refactor yet.

--- a/research/STASHED_IDEMPOTENCY_DISCUSSION.md
+++ b/research/STASHED_IDEMPOTENCY_DISCUSSION.md
@@ -1,0 +1,26 @@
+# Idempotency Discussion (Stashed)
+
+## Problem
+`sendMessage()` calls `POST /session/:id/prompt_async` which is NOT idempotent. Retrying on failure could create duplicate messages.
+
+## Options Considered
+
+1. **Don't retry** - Simple, no duplicates, bad UX for transient failures
+
+2. **Retry only on connection errors** (recommended for quick fix)
+   - Connection refused (curl exit 7) = safe to retry (never received)
+   - HTTP errors / timeouts = unsafe (may have been queued)
+   - Requires careful error classification
+
+3. **Client-side deduplication**
+   - Generate unique `messageId` per request
+   - Track sent messageIds, check SSE for responses
+   - If no SSE activity, safe to retry
+
+4. **Request OpenCode add idempotency key support**
+   - Standard pattern: `Idempotency-Key: <uuid>` header
+   - Server deduplicates
+   - Best solution, requires upstream change
+
+## Decision
+TBD - discuss with user


### PR DESCRIPTION
## Summary

- Use async endpoint (`prompt_async`) instead of sync - prevents timeout on long-running operations
- Increase SSE timeout to 10 minutes for complex tool-use operations
- Filter SSE events by sessionID to prevent cross-session interference
- Remove duplicate error emission
- Verify session exists before using saved agentSessionId

## Root Cause

The sync `/session/:id/message` endpoint blocks until the AI completes processing. Our curl had a 30-second timeout, so any operation taking longer would fail with "Connection failed". The async endpoint returns 204 immediately and we rely on SSE for the response.

## Test plan

- [x] Multi-message conversation test passes
- [x] Long-running operation with tool calls completes without timeout
- [x] Invalid session ID gracefully creates new session
- [ ] Manual testing in web/mobile UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)