### PR TITLE
Add --all flag to sync command

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -119,6 +119,18 @@ export class ApiClient {
     }
   }
 
+  async syncAllWorkspaces(): Promise<{
+    synced: number;
+    failed: number;
+    results: { name: string; success: boolean; error?: string }[];
+  }> {
+    try {
+      return await this.client.workspaces.syncAll();
+    } catch (err) {
+      throw this.wrapError(err);
+    }
+  }
+
   async getPortForwards(name: string): Promise<number[]> {
     try {
       const result = await this.client.workspaces.getPortForwards({ name });


### PR DESCRIPTION
## Summary
- Adds `-a, --all` flag to `perry sync` command
- Syncs credentials and files to all running workspaces at once
- Shows per-workspace status with checkmarks/failures and a summary

## Test plan
- [ ] Run `perry sync --help` and verify `--all` flag is documented
- [ ] Run `perry sync --all` with running workspaces and verify output
- [ ] Run `perry sync --all` with no running workspaces
- [ ] Run `perry sync` without name or `--all` and verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)