### PR TITLE
fix: environment variables not available in VSCode Remote terminals

### DIFF
--- a/perry/internal/src/commands/entrypoint.ts
+++ b/perry/internal/src/commands/entrypoint.ts
@@ -2,6 +2,7 @@ import { addSshKeys } from "./add-ssh-key";
 import { syncUserWithHost } from "./sync-user";
 import { ensureDockerd, monitorServices, startSshd, tailDockerdLogs, waitForDocker } from "../lib/services";
 import { runCommand } from "../lib/process";
+import { writeEnvironmentFile } from "../lib/environment";
 
 export const runEntrypoint = async () => {
   console.log("[entrypoint] Syncing user with host...");
@@ -27,6 +28,12 @@ export const runEntrypoint = async () => {
   } catch (error) {
     console.log(`[entrypoint] Initialization failed (non-fatal): ${(error as Error).message}`);
     console.log("[entrypoint] SSH will still start - connect to debug the issue");
+  }
+  console.log("[entrypoint] Writing environment file...");
+  try {
+    await writeEnvironmentFile(process.env as Record<string, string>);
+  } catch (error) {
+    console.log(`[entrypoint] Failed to write environment file (non-fatal): ${(error as Error).message}`);
   }
   console.log("[entrypoint] Starting SSH daemon...");
   await startSshd();

--- a/perry/internal/src/lib/environment.ts
+++ b/perry/internal/src/lib/environment.ts
@@ -1,0 +1,95 @@
+import { promises as fs } from "fs";
+
+const SYSTEM_VARS = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "PWD",
+  "OLDPWD",
+  "TERM",
+  "COLORTERM",
+  "SHLVL",
+  "HOSTNAME",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "_",
+  "LS_COLORS",
+  "LESSOPEN",
+  "LESSCLOSE",
+  "XDG_SESSION_ID",
+  "XDG_RUNTIME_DIR",
+  "XDG_DATA_DIRS",
+  "XDG_CONFIG_DIRS",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "SSH_CLIENT",
+  "SSH_CONNECTION",
+  "SSH_TTY",
+  "SSH_AUTH_SOCK",
+  "MAIL",
+  "MOTD_SHOWN",
+  "DOCKER_HOST",
+  "DOCKER_TLS_VERIFY",
+  "DOCKER_CERT_PATH",
+  "DOCKER_BUILDKIT",
+  "COMPOSE_DOCKER_CLI_BUILD",
+  "BUN_INSTALL",
+  "GOPATH",
+  "GOROOT",
+  "NVM_DIR",
+  "NVM_BIN",
+  "NVM_INC",
+  "NODE_PATH",
+  "WORKSPACE_HOME",
+  "WORKSPACE_RUNTIME_CONFIG",
+  "HOST_HOME",
+  "HOST_UID",
+  "HOST_GID",
+  "GIT_REPO",
+  "BRANCH",
+  "WORKSPACE_REPO_URL",
+  "WORKSPACE_REPO_BRANCH",
+  "SSH_PUBLIC_KEY",
+]);
+
+const shouldIncludeVar = (key: string): boolean => {
+  if (SYSTEM_VARS.has(key)) {
+    return false;
+  }
+  if (key.startsWith("PERRY_INTERNAL_")) {
+    return false;
+  }
+  return true;
+};
+
+const escapeValue = (value: string): string => {
+  if (value.includes("\n") || value.includes('"') || value.includes("'")) {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
+  }
+  if (value.includes(" ") || value.includes("$") || value.includes("`")) {
+    return `"${value}"`;
+  }
+  return value;
+};
+
+export const writeEnvironmentFile = async (
+  vars: Record<string, string | undefined>,
+  filePath = "/etc/environment"
+): Promise<void> => {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (!shouldIncludeVar(key)) {
+      continue;
+    }
+    lines.push(`${key}=${escapeValue(value)}`);
+  }
+  lines.sort();
+  const content = lines.length ? `${lines.join("\n")}\n` : "";
+  await fs.writeFile(filePath, content, "utf8");
+};


### PR DESCRIPTION
## Summary
- Add /etc/environment support for environment variables in all session types
- Write env vars before starting sshd in container entrypoint
- Sync env vars when credentials are updated via API
- Fixes VSCode Remote terminals not having access to GITHUB_TOKEN and other secrets

## Test plan
- [x] Build workspace image with changes
- [x] Create test workspace with configured secrets
- [x] Verify env vars available in SSH sessions
- [x] Verify env vars available in VSCode Remote terminals
- [x] Verify credential sync updates /etc/environment