### PR TITLE
fix: restart agent and sync workspaces on update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,8 +117,12 @@ download_and_install() {
 
   local extracted_dir="$tmp_dir/perry-${version}-${platform}"
 
-  cp "$extracted_dir/$binary_name" "$BIN_DIR/perry"
-  chmod +x "$BIN_DIR/perry"
+  local target="$BIN_DIR/perry"
+  local tmp_target="$BIN_DIR/.perry.tmp.$$"
+
+  cp "$extracted_dir/$binary_name" "$tmp_target"
+  chmod +x "$tmp_target"
+  mv -f "$tmp_target" "$target"
 
   if [[ -d "$extracted_dir/web" ]]; then
     rm -rf "$INSTALL_DIR/web"


### PR DESCRIPTION
## Summary
- Make `perry update` restart the local agent if it was running (systemd service or foreground `perry agent run`), then wait for it to become healthy.
- After updating, automatically sync all running workspaces so container `/usr/local/bin/perry` matches the updated host binary.
- Update `install.sh` to install the binary via an atomic `mv` to avoid `Text file busy` when updating a running agent.

## Notes
- If the agent was not running before update, it remains stopped and workspace sync is skipped.
- If the agent fails to become healthy after restart, the command reports how to view logs and how to run `perry sync --all` manually.