### PR TITLE
chore: make validate fast by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,21 @@ Read `DESIGN.md` for comprehensive architecture, data models, and API specificat
 
 ## Validation
 
-**Recommended validation (full suite):**
+**Default local validation (fast):**
 
 ```bash
-bun run validate  # Complete validation suite: lint + build + test + web tests
+bun run validate  # Core: lint + format + build TS/worker + unit tests
 ```
+
+**Full validation (slow):**
+
+```bash
+bun run validate:full  # Core + web build/lint + Playwright
+```
+
+Guideline: run `bun run validate` for most iterations; run `bun run validate:full` when you touch the web UI, or when you’re changing core workspace/agent behavior and want end-to-end confidence.
+
+When adding/changing behavior, add tests and run the most relevant ones (unit/integration/e2e) instead of always running the full suite locally.
 
 ## Release
 
@@ -18,7 +28,7 @@ To cut a new release:
 
 ```bash
 # 1) Validate (optional; CI will run on tag)
-# bun run validate
+# bun run validate:full
 
 # 2) Bump version in package.json (patch/minor/major)
 # Example: 0.3.13 -> 0.3.14
@@ -36,9 +46,11 @@ git push origin v<x.y.z>
 **Incremental validation during development:**
 
 ```bash
-bun run check     # Quick: lint + format + typecheck
-bun run build     # Build CLI, worker binary, and web UI
-bun run test      # Unit/integration tests (requires Docker)
+bun run check          # Quick: lint + format + typecheck
+bun run validate       # Fast: lint + format + build TS/worker + unit tests
+bun run validate:full  # Slow: validate + web build/lint + Playwright
+bun run build          # Build CLI, worker binary, and web UI
+bun run test           # Unit/integration tests (requires Docker)
 ```
 
 **Manual verification required:**
@@ -107,7 +119,7 @@ curl -X POST "http://localhost:7391/rpc/sessions/list" \
 
 ## Requirements
 
-- Prefer `bun run validate` before marking tasks complete (CI runs on PRs/tags)
+- Prefer `bun run validate` for iteration; run the tests you add/affect, and use `bun run validate:full` when appropriate (web UI / end-to-end changes)
 - Test with real Docker containers
 - Use SSH for user interaction (not `docker exec`)
 - Follow naming: `workspace-<name>` containers, `workspace-internal-` resources  

--- a/package.json
+++ b/package.json
@@ -16,12 +16,18 @@
     "build:worker": "bun build src/index.ts --compile --outfile dist/perry-worker --target=bun",
     "build:web": "cd web && bun run build",
     "test": "vitest run",
+    "test:unit": "vitest run --config vitest.unit.config.js",
     "test:web": "playwright test",
     "lint": "oxlint --type-aware --tsconfig=tsconfig.json src/ && oxlint mobile/src/",
     "format:check": "oxfmt --check src/ test/",
     "check": "bun run lint && bun run format:check && bun x tsc --noEmit",
     "lint:web": "cd web && bun run lint",
-    "validate": "bun run check && bun run build && bun run test && bun run lint:web && bun run test:web",
+
+    "validate:core": "bun run lint && bun run format:check && bun run build:ts && bun run build:worker && bun run test:unit",
+    "validate:web": "bun run build:web && bun run lint:web && bun run test:web",
+    "validate:full": "bun run validate:core && bun run validate:web",
+    "validate": "bun run validate:core",
+
     "build:binaries": "bun run scripts/build-binaries.ts"
   },
   "engines": {

--- a/vitest.unit.config.js
+++ b/vitest.unit.config.js
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+    fileParallelism: true,
+    mockReset: true,
+    exclude: [
+      '**/node_modules/**',
+      '**/test/web/**',
+      '**/test/tui/**',
+      '**/web/e2e/**',
+      '**/test/integration/**',
+      '**/test/e2e/**',
+      '**/test/worker/server.test.ts',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- Make `bun run validate` fast by default (`validate:core`): lint + format + build TS/worker + unit tests only.
- Add `test:unit` and `vitest.unit.config.js` to avoid Docker-heavy global setup for unit tests.
- Keep `validate:full` for web build/lint + Playwright + core.
- Update `AGENTS.md` guidance to emphasize running the most relevant tests you add/affect.

## Why
`vitest` previously always ran Docker global setup (image build/cleanup), making local validation slow even for pure unit changes.