### PR TITLE
fix: improve opencode model selection and display

### DIFF
--- a/src/models/discovery.ts
+++ b/src/models/discovery.ts
@@ -100,11 +100,13 @@ function parseOpencodeModels(output: string): ModelInfo[] {
 
     const parts = trimmed.split('/');
     const id = trimmed;
-    const name = parts.length > 1 ? parts[1] : parts[0];
-    const displayName = name
+    const provider = parts.length > 1 ? parts[0] : '';
+    const modelName = parts.length > 1 ? parts[1] : parts[0];
+    const formattedModel = modelName
       .split('-')
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
       .join(' ');
+    const displayName = provider ? `${provider} / ${formattedModel}` : formattedModel;
 
     models.push({
       id,
@@ -142,4 +144,4 @@ export async function discoverContainerOpencodeModels(
   }
 }
 
-export { FALLBACK_CLAUDE_MODELS };
+export { FALLBACK_CLAUDE_MODELS, parseOpencodeModels };

--- a/test/models/discovery.test.ts
+++ b/test/models/discovery.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'vitest';
+import { parseOpencodeModels } from '../../src/models/discovery';
+
+describe('parseOpencodeModels', () => {
+  test('parses model with provider prefix', () => {
+    const output = 'opencode/claude-opus-4-5';
+    const models = parseOpencodeModels(output);
+
+    expect(models).toHaveLength(1);
+    expect(models[0].id).toBe('opencode/claude-opus-4-5');
+    expect(models[0].name).toBe('opencode / Claude Opus 4 5');
+  });
+
+  test('includes provider in display name for disambiguation', () => {
+    const output = `opencode/claude-opus-4-5
+github-copilot/claude-opus-4.5`;
+    const models = parseOpencodeModels(output);
+
+    expect(models).toHaveLength(2);
+    expect(models[0].name).toBe('opencode / Claude Opus 4 5');
+    expect(models[1].name).toBe('github-copilot / Claude Opus 4.5');
+    expect(models[0].name).not.toBe(models[1].name);
+  });
+
+  test('handles model without provider prefix', () => {
+    const output = 'sonnet';
+    const models = parseOpencodeModels(output);
+
+    expect(models).toHaveLength(1);
+    expect(models[0].id).toBe('sonnet');
+    expect(models[0].name).toBe('Sonnet');
+  });
+
+  test('parses multiple models', () => {
+    const output = `opencode/claude-opus-4-5
+opencode/claude-sonnet-4
+opencode/gpt-5
+github-copilot/claude-opus-4.5`;
+    const models = parseOpencodeModels(output);
+
+    expect(models).toHaveLength(4);
+    expect(models.map((m) => m.id)).toEqual([
+      'opencode/claude-opus-4-5',
+      'opencode/claude-sonnet-4',
+      'opencode/gpt-5',
+      'github-copilot/claude-opus-4.5',
+    ]);
+  });
+
+  test('skips empty lines', () => {
+    const output = `opencode/claude-opus-4-5
+
+opencode/claude-sonnet-4`;
+    const models = parseOpencodeModels(output);
+
+    expect(models).toHaveLength(2);
+  });
+
+  test('skips JSON lines', () => {
+    const output = `{"error": "some error"}
+opencode/claude-opus-4-5`;
+    const models = parseOpencodeModels(output);
+
+    expect(models).toHaveLength(1);
+    expect(models[0].id).toBe('opencode/claude-opus-4-5');
+  });
+
+  test('capitalizes each word in model name', () => {
+    const output = 'opencode/gpt-5.1-codex-max';
+    const models = parseOpencodeModels(output);
+
+    expect(models[0].name).toBe('opencode / Gpt 5.1 Codex Max');
+  });
+});


### PR DESCRIPTION
## Summary

- Show provider prefix in model names (e.g., `opencode / Claude Opus 4 5`) to disambiguate between providers with similar model names
- Enable mid-conversation model switching for opencode (was previously disabled)
- Fix WebSocket reconnection when changing models for opencode
- Fix race condition where saved config could override user's explicit model selection

## Problem

When using opencode, selecting a model from the dropdown could silently fail because:
1. Model names like "Claude Opus 4.5" appeared multiple times from different providers (opencode, github-copilot) with no way to tell them apart
2. Selecting a github-copilot model would fail with "Personal Access Tokens are not supported" since the opencode API key doesn't work with github-copilot endpoints
3. Model changes for opencode didn't reconnect the WebSocket, so the selection was ignored
4. A race condition could cause saved config to override the user's explicit dropdown selection

## Test plan

- [ ] Verify model dropdown shows provider prefix (e.g., `opencode / Claude Opus 4 5`)
- [ ] Verify changing model mid-conversation works for opencode (starts new session)
- [ ] Verify selecting a model before sending first message uses that model
- [ ] Run `bun run validate` - all 202 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)