### PR TITLE
Remove npm publishing from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,47 +129,6 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  npm:
-    needs: merge
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Update npm to latest
-        run: npm install -g npm@latest
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: |
-          bun install
-          cd web && bun install
-
-      - name: Set version from tag
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          npm version $VERSION --no-git-tag-version --allow-same-version
-
-      - name: Build
-        run: bun run build
-
-      - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   binaries:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Remove npm publishing job from release workflow
- Distribution is now centralized on the install script with GitHub releases binaries

## Cleanup reminder
After merging, consider:
- Removing `NPM_TOKEN` secret from repo settings
- Deprecating the npm package: `npm deprecate @gricha/perry "Use install script instead"`
- Optionally removing `bin`, `files`, and `publishConfig` from package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)