### PR TITLE
Fix sync --all hanging on docker cp

### DIFF
--- a/src/agents/sync/copier.ts
+++ b/src/agents/sync/copier.ts
@@ -23,7 +23,7 @@ export function createDockerFileCopier(): FileCopier {
         user: 'workspace',
       });
 
-      await docker.copyToContainer(containerName, expandedSource, file.dest);
+      await docker.copyToContainer(containerName, expandedSource, file.dest, { timeoutMs: 60_000 });
       await docker.execInContainer(containerName, ['chown', 'workspace:workspace', file.dest], {
         user: 'root',
       });
@@ -43,7 +43,9 @@ export function createDockerFileCopier(): FileCopier {
         await docker.execInContainer(containerName, ['mkdir', '-p', dir.dest], {
           user: 'workspace',
         });
-        await docker.copyToContainer(containerName, tempTar, '/tmp/agent-sync.tar');
+        await docker.copyToContainer(containerName, tempTar, '/tmp/agent-sync.tar', {
+          timeoutMs: 60_000,
+        });
         await docker.execInContainer(
           containerName,
           ['tar', '-xf', '/tmp/agent-sync.tar', '-C', dir.dest],
@@ -79,7 +81,7 @@ export function createDockerFileCopier(): FileCopier {
           user: 'workspace',
         });
 
-        await docker.copyToContainer(containerName, tempFile, config.dest);
+        await docker.copyToContainer(containerName, tempFile, config.dest, { timeoutMs: 60_000 });
         await docker.execInContainer(containerName, ['chown', 'workspace:workspace', config.dest], {
           user: 'root',
         });

--- a/test/unit/docker-timeout.test.ts
+++ b/test/unit/docker-timeout.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('child_process', () => {
+  const spawn = vi.fn(() => {
+    const stdoutHandlers: Array<(chunk: Buffer) => void> = [];
+    const stderrHandlers: Array<(chunk: Buffer) => void> = [];
+    const closeHandlers: Array<(code: number) => void> = [];
+
+    const child = {
+      stdout: {
+        on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+          if (event === 'data') stdoutHandlers.push(cb);
+        }),
+      },
+      stderr: {
+        on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+          if (event === 'data') stderrHandlers.push(cb);
+        }),
+      },
+      on: vi.fn((event: string, cb: (arg: unknown) => void) => {
+        if (event === 'close') closeHandlers.push(cb as (code: number) => void);
+      }),
+      kill: vi.fn(),
+      __emitStdout(chunk: string) {
+        for (const cb of stdoutHandlers) cb(Buffer.from(chunk));
+      },
+      __emitStderr(chunk: string) {
+        for (const cb of stderrHandlers) cb(Buffer.from(chunk));
+      },
+      __emitClose(code: number) {
+        for (const cb of closeHandlers) cb(code);
+      },
+    };
+
+    return child;
+  });
+
+  return { spawn };
+});
+
+describe('docker command timeouts', () => {
+  it('times out docker cp when timeoutMs specified', async () => {
+    vi.useFakeTimers();
+
+    const { copyToContainer } = await import('../../src/docker');
+
+    const promise = copyToContainer('container', '/host/file', '/dest', { timeoutMs: 10 });
+    const assertion = expect(promise).rejects.toThrow(/timed out/i);
+
+    await vi.advanceTimersByTimeAsync(11);
+    await assertion;
+
+    vi.useRealTimers();
+  });
+});

--- a/test/unit/worker-binary-copy-timeout.test.ts
+++ b/test/unit/worker-binary-copy-timeout.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('fs/promises', () => {
+  return {
+    default: {
+      access: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('.gitconfig')) {
+          const err = new Error('ENOENT') as NodeJS.ErrnoException;
+          err.code = 'ENOENT';
+          throw err;
+        }
+
+        // Make copyPerryWorker() find the compiled worker binary.
+        if (filePath.endsWith('/perry-worker')) {
+          return;
+        }
+
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      }),
+    },
+  };
+});
+
+vi.mock('../../src/docker', () => {
+  return {
+    getContainerName: (name: string) => `workspace-${name}`,
+    copyToContainer: vi.fn(() => {
+      throw new Error('Command timed out: docker cp ...');
+    }),
+    execInContainer: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0, code: 0 })),
+    containerRunning: vi.fn(async () => true),
+    getContainerIp: vi.fn(async () => '127.0.0.1'),
+  };
+});
+
+vi.mock('../../src/agents', () => ({
+  syncAllAgents: vi.fn(async () => ({
+    'claude-code': { copied: [], generated: [], skipped: [], errors: [] },
+    opencode: { copied: [], generated: [], skipped: [], errors: [] },
+    codex: { copied: [], generated: [], skipped: [], errors: [] },
+  })),
+}));
+
+describe('workspace sync worker binary copy', () => {
+  it('surfaces a helpful error when worker binary copy times out', async () => {
+    const { WorkspaceManager } = await import('../../src/workspace/manager');
+
+    const manager = new WorkspaceManager('/tmp/perry-test-config', {
+      port: 7777,
+      credentials: { env: {}, files: {} },
+      scripts: {},
+    });
+
+    // Avoid touching real FS state file.
+    (manager as any).state = {
+      getWorkspace: vi.fn(async () => ({
+        name: 'ws',
+        status: 'running',
+        containerId: 'abcdef',
+        created: new Date().toISOString(),
+        ports: { ssh: 2222 },
+        lastUsed: new Date().toISOString(),
+      })),
+    };
+
+    await expect(manager.sync('ws')).rejects.toThrow(/Timed out copying perry worker binary/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add timeouts to Docker command runner and propagate to `docker cp` operations to prevent indefinite hangs during `perry sync --all`.
- Improve error message when the worker-binary copy to a workspace times out.
- Add unit coverage for docker-cp timeout and worker-binary timeout messaging.

## Testing
- `bun run validate`