### PR TITLE
fix(mobile): remove aggressive scroll restoration during streaming

### DIFF
--- a/mobile/src/screens/SessionChatScreen.tsx
+++ b/mobile/src/screens/SessionChatScreen.tsx
@@ -782,11 +782,6 @@ export function SessionChatScreen({ route, navigation }: any) {
     return cleanup
   }, [connect])
 
-  useEffect(() => {
-    if (streamingParts.length > 0 && isAtBottomRef.current) {
-      setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 50)
-    }
-  }, [streamingParts])
 
   const handleScroll = useCallback((event: any) => {
     const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent
@@ -931,7 +926,11 @@ export function SessionChatScreen({ route, navigation }: any) {
           ) : null
         }
         onScrollToIndexFailed={() => {}}
-        maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
+        onContentSizeChange={() => {
+          if (isAtBottomRef.current) {
+            flatListRef.current?.scrollToEnd({ animated: false })
+          }
+        }}
       />
       )}
 


### PR DESCRIPTION
## Summary
- Remove `maintainVisibleContentPosition={{ minIndexForVisible: 0 }}` which was causing the chat to yank users back to the middle when scrolling during streaming
- Replace timeout-based `scrollToEnd` calls with `onContentSizeChange` handler that respects user scroll position
- Only auto-scroll to bottom when user is already at bottom (`isAtBottomRef.current`)

## Test plan
- [ ] Start a chat, send message, verify auto-scroll to bottom works during streaming
- [ ] Scroll up during streaming, verify you stay where you scrolled (no yanking back)
- [ ] Scroll back to bottom during streaming, verify you stay at bottom
- [ ] Test with long responses to verify no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)