### PR TITLE
feat(mobile): refactor settings to use navigation-based sections

### DIFF
--- a/mobile/src/navigation/TabNavigator.tsx
+++ b/mobile/src/navigation/TabNavigator.tsx
@@ -3,7 +3,17 @@ import { HomeScreen } from '../screens/HomeScreen';
 import { WorkspaceDetailScreen } from '../screens/WorkspaceDetailScreen';
 import { SessionChatScreen } from '../screens/SessionChatScreen';
 import { TerminalScreen } from '../screens/TerminalScreen';
-import { SettingsScreen } from '../screens/SettingsScreen';
+import {
+  SettingsScreen,
+  ConnectionSettingsScreen,
+  ThemeSettingsScreen,
+  AgentsSettingsScreen,
+  EnvironmentSettingsScreen,
+  FilesSettingsScreen,
+  ScriptsSettingsScreen,
+  SyncSettingsScreen,
+  AboutSettingsScreen,
+} from '../screens/SettingsScreen';
 import { SkillsScreen } from '../screens/SkillsScreen';
 import { McpServersScreen } from '../screens/McpServersScreen';
 import { WorkspaceSettingsScreen } from '../screens/WorkspaceSettingsScreen';
@@ -20,6 +30,14 @@ export function TabNavigator() {
     >
       <Stack.Screen name="Home" component={HomeScreen} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
+      <Stack.Screen name="SettingsConnection" component={ConnectionSettingsScreen} />
+      <Stack.Screen name="SettingsTheme" component={ThemeSettingsScreen} />
+      <Stack.Screen name="SettingsAgents" component={AgentsSettingsScreen} />
+      <Stack.Screen name="SettingsEnvironment" component={EnvironmentSettingsScreen} />
+      <Stack.Screen name="SettingsFiles" component={FilesSettingsScreen} />
+      <Stack.Screen name="SettingsScripts" component={ScriptsSettingsScreen} />
+      <Stack.Screen name="SettingsSync" component={SyncSettingsScreen} />
+      <Stack.Screen name="SettingsAbout" component={AboutSettingsScreen} />
       <Stack.Screen name="Skills" component={SkillsScreen} />
       <Stack.Screen name="Mcp" component={McpServersScreen} />
       <Stack.Screen name="WorkspaceDetail" component={WorkspaceDetailScreen} />


### PR DESCRIPTION
## Summary
- Convert settings from single scrolling screen to navigation pattern (matching web UI)
- Settings index shows categorized list with chevron navigation
- Each section opens as its own screen with back navigation

**Sections:**
- **General:** Connection, Appearance (theme)
- **Agent Configuration:** Coding Agents, Skills, MCP Servers
- **Workspace:** Environment Variables, File Mappings, Scripts, Sync
- **Info:** About

## Test plan
- [ ] Open Settings from home screen
- [ ] Verify section list displays correctly with grouped categories
- [ ] Tap each section and verify it navigates to dedicated screen
- [ ] Verify back button returns to settings index
- [ ] Test saving changes in each settings screen
- [ ] Verify theme changes apply immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)