### PR TITLE
fix(mobile): prevent network status infinite re-render loop

### DIFF
--- a/mobile/src/lib/network.tsx
+++ b/mobile/src/lib/network.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, Animated } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import NetInfo, { NetInfoState } from '@react-native-community/netinfo'
@@ -35,6 +35,8 @@ export function NetworkProvider({ children }: NetworkProviderProps) {
   const [isOnline, setIsOnline] = useState(true)
   const [lastError, setLastError] = useState<string | null>(null)
   const [serverHostname, setServerHostname] = useState<string | null>(null)
+  const statusRef = useRef<ConnectionStatus>(status)
+  statusRef.current = status
 
   const checkConnection = useCallback(async () => {
     setStatus('connecting')
@@ -73,13 +75,13 @@ export function NetworkProvider({ children }: NetworkProviderProps) {
       if (!online) {
         setStatus('disconnected')
         setLastError('No network connection')
-      } else if (status === 'disconnected') {
+      } else if (statusRef.current === 'disconnected') {
         checkConnection()
       }
     })
 
     const interval = setInterval(() => {
-      if (status === 'server-unreachable' || status === 'disconnected') {
+      if (statusRef.current === 'server-unreachable' || statusRef.current === 'disconnected') {
         checkConnection()
       }
     }, 30000)
@@ -88,7 +90,7 @@ export function NetworkProvider({ children }: NetworkProviderProps) {
       unsubscribe()
       clearInterval(interval)
     }
-  }, [checkConnection, status])
+  }, [checkConnection])
 
   return (
     <NetworkContext.Provider value={{ status, isOnline, lastError, checkConnection, serverHostname }}>


### PR DESCRIPTION
## Summary
Fix the jitter/flickering on the Settings screen where the "Connected/Disconnected" label was rapidly changing.

**Root cause:** The `useEffect` in `NetworkProvider` had `status` in its dependency array:
```javascript
}, [checkConnection, status])  // status causes infinite loop
```

This caused:
1. Effect runs → `checkConnection()` → sets status to 'connecting'
2. Status change → effect cleanup + re-runs
3. `checkConnection()` called again → status changes
4. Infinite loop causing visible jitter

**Fix:** Use a `statusRef` to read current status in callbacks without adding it to effect dependencies.

## Test plan
- [ ] Open Settings screen
- [ ] Verify "Connected" label is stable (no flickering)
- [ ] Disconnect network, verify status updates correctly
- [ ] Reconnect network, verify auto-reconnection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)