### PR TITLE
Validate workspace names across API and clients

### DIFF
--- a/mobile/src/lib/workspace-name.ts
+++ b/mobile/src/lib/workspace-name.ts
@@ -1,0 +1,29 @@
+import { HOST_WORKSPACE_NAME } from './api';
+
+export const USER_WORKSPACE_NAME_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export function getUserWorkspaceNameError(rawName: string): string | null {
+  const name = rawName.trim();
+
+  if (name.length === 0) {
+    return 'Workspace name is required';
+  }
+
+  if (name === HOST_WORKSPACE_NAME) {
+    return 'Workspace name is reserved';
+  }
+
+  if (name.length > 63) {
+    return 'Workspace name must be 63 characters or less';
+  }
+
+  if (!USER_WORKSPACE_NAME_REGEX.test(name)) {
+    return 'Use lowercase letters, numbers, and hyphens; start/end with a letter or number';
+  }
+
+  return null;
+}
+
+export function isValidUserWorkspaceName(name: string): boolean {
+  return getUserWorkspaceNameError(name) === null;
+}

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import type { AgentConfig } from '../shared/types';
 import { HOST_WORKSPACE_NAME } from '../shared/client-types';
+import { AnyWorkspaceNameSchema, UserWorkspaceNameSchema } from '../shared/workspace-name';
 import { getDockerVersion, execInContainer, getContainerName, type ExecResult } from '../docker';
 import { createWorkerClient } from '../worker/client';
 import type { WorkspaceManager } from '../workspace/manager';
@@ -207,31 +208,33 @@ export function createRouter(ctx: RouterContext) {
     return ctx.workspaces.list();
   });
 
-  const getWorkspace = os.input(z.object({ name: z.string() })).handler(async ({ input }) => {
-    const workspace = await ctx.workspaces.get(input.name);
-    if (!workspace) {
-      throw new ORPCError('NOT_FOUND', { message: 'Workspace not found' });
-    }
-
-    let workerVersion: string | null = null;
-    if (workspace.status === 'running') {
-      try {
-        const containerName = getContainerName(input.name);
-        const client = await createWorkerClient(containerName);
-        const health = await client.health();
-        workerVersion = health.version;
-      } catch {
-        // Worker not reachable
+  const getWorkspace = os
+    .input(z.object({ name: UserWorkspaceNameSchema }))
+    .handler(async ({ input }) => {
+      const workspace = await ctx.workspaces.get(input.name);
+      if (!workspace) {
+        throw new ORPCError('NOT_FOUND', { message: 'Workspace not found' });
       }
-    }
 
-    return { ...workspace, workerVersion };
-  });
+      let workerVersion: string | null = null;
+      if (workspace.status === 'running') {
+        try {
+          const containerName = getContainerName(input.name);
+          const client = await createWorkerClient(containerName);
+          const health = await client.health();
+          workerVersion = health.version;
+        } catch {
+          // Worker not reachable
+        }
+      }
+
+      return { ...workspace, workerVersion };
+    });
 
   const createWorkspace = os
     .input(
       z.object({
-        name: z.string(),
+        name: UserWorkspaceNameSchema,
         clone: z.string().optional(),
         env: z.record(z.string(), z.string()).optional(),
       })
@@ -245,20 +248,22 @@ export function createRouter(ctx: RouterContext) {
       }
     });
 
-  const deleteWorkspace = os.input(z.object({ name: z.string() })).handler(async ({ input }) => {
-    try {
-      ctx.terminalServer.closeConnectionsForWorkspace(input.name);
-      await ctx.workspaces.delete(input.name);
-      return { success: true };
-    } catch (err) {
-      mapErrorToORPC(err, 'Failed to delete workspace');
-    }
-  });
+  const deleteWorkspace = os
+    .input(z.object({ name: UserWorkspaceNameSchema }))
+    .handler(async ({ input }) => {
+      try {
+        ctx.terminalServer.closeConnectionsForWorkspace(input.name);
+        await ctx.workspaces.delete(input.name);
+        return { success: true };
+      } catch (err) {
+        mapErrorToORPC(err, 'Failed to delete workspace');
+      }
+    });
 
   const startWorkspace = os
     .input(
       z.object({
-        name: z.string(),
+        name: UserWorkspaceNameSchema,
         clone: z.string().optional(),
         env: z.record(z.string(), z.string()).optional(),
       })
@@ -276,7 +281,7 @@ export function createRouter(ctx: RouterContext) {
     });
 
   const stopWorkspace = os
-    .input(z.object({ name: z.string() }))
+    .input(z.object({ name: UserWorkspaceNameSchema }))
     .output(WorkspaceInfoSchema)
     .handler(async ({ input }) => {
       try {
@@ -288,7 +293,7 @@ export function createRouter(ctx: RouterContext) {
     });
 
   const getLogs = os
-    .input(z.object({ name: z.string(), tail: z.number().optional().default(100) }))
+    .input(z.object({ name: UserWorkspaceNameSchema, tail: z.number().optional().default(100) }))
     .handler(async ({ input }) => {
       try {
         return await ctx.workspaces.getLogs(input.name, input.tail);
@@ -297,14 +302,16 @@ export function createRouter(ctx: RouterContext) {
       }
     });
 
-  const syncWorkspace = os.input(z.object({ name: z.string() })).handler(async ({ input }) => {
-    try {
-      await ctx.workspaces.sync(input.name);
-      return { success: true };
-    } catch (err) {
-      mapErrorToORPC(err, 'Failed to sync workspace');
-    }
-  });
+  const syncWorkspace = os
+    .input(z.object({ name: UserWorkspaceNameSchema }))
+    .handler(async ({ input }) => {
+      try {
+        await ctx.workspaces.sync(input.name);
+        return { success: true };
+      } catch (err) {
+        mapErrorToORPC(err, 'Failed to sync workspace');
+      }
+    });
 
   const syncAllWorkspaces = os.handler(async () => {
     const workspaces = await ctx.workspaces.list();
@@ -327,17 +334,19 @@ export function createRouter(ctx: RouterContext) {
     };
   });
 
-  const updateWorker = os.input(z.object({ name: z.string() })).handler(async ({ input }) => {
-    try {
-      await ctx.workspaces.updateWorkerBinary(input.name);
-      return { success: true };
-    } catch (err) {
-      mapErrorToORPC(err, 'Failed to update worker');
-    }
-  });
+  const updateWorker = os
+    .input(z.object({ name: UserWorkspaceNameSchema }))
+    .handler(async ({ input }) => {
+      try {
+        await ctx.workspaces.updateWorkerBinary(input.name);
+        return { success: true };
+      } catch (err) {
+        mapErrorToORPC(err, 'Failed to update worker');
+      }
+    });
 
   const touchWorkspace = os
-    .input(z.object({ name: z.string() }))
+    .input(z.object({ name: UserWorkspaceNameSchema }))
     .output(WorkspaceInfoSchema)
     .handler(async ({ input }) => {
       const workspace = await ctx.workspaces.touch(input.name);
@@ -348,7 +357,7 @@ export function createRouter(ctx: RouterContext) {
     });
 
   const getPortForwards = os
-    .input(z.object({ name: z.string() }))
+    .input(z.object({ name: UserWorkspaceNameSchema }))
     .output(z.object({ forwards: z.array(PortMappingSchema) }))
     .handler(async ({ input }) => {
       try {
@@ -360,7 +369,7 @@ export function createRouter(ctx: RouterContext) {
     });
 
   const setPortForwards = os
-    .input(z.object({ name: z.string(), forwards: z.array(PortMappingSchema) }))
+    .input(z.object({ name: UserWorkspaceNameSchema, forwards: z.array(PortMappingSchema) }))
     .output(WorkspaceInfoSchema)
     .handler(async ({ input }) => {
       try {
@@ -373,8 +382,8 @@ export function createRouter(ctx: RouterContext) {
   const cloneWorkspace = os
     .input(
       z.object({
-        sourceName: z.string(),
-        cloneName: z.string(),
+        sourceName: UserWorkspaceNameSchema,
+        cloneName: UserWorkspaceNameSchema,
       })
     )
     .output(WorkspaceInfoSchema)
@@ -389,7 +398,7 @@ export function createRouter(ctx: RouterContext) {
   const execInWorkspace = os
     .input(
       z.object({
-        name: z.string(),
+        name: UserWorkspaceNameSchema,
         command: z.union([z.string(), z.array(z.string())]),
         timeout: z.number().optional(),
       })
@@ -916,7 +925,7 @@ export function createRouter(ctx: RouterContext) {
   const listSessions = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         agentType: z.enum(['claude-code', 'opencode', 'codex']).optional(),
         limit: z.number().optional().default(50),
         offset: z.number().optional().default(0),
@@ -929,7 +938,7 @@ export function createRouter(ctx: RouterContext) {
   const getSession = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         sessionId: z.string(),
         agentType: z.enum(['claude-code', 'opencode', 'codex']).optional(),
         projectPath: z.string().optional(),
@@ -1022,7 +1031,7 @@ export function createRouter(ctx: RouterContext) {
   const renameSession = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         sessionId: z.string(),
         name: z.string().min(1).max(200),
       })
@@ -1035,7 +1044,7 @@ export function createRouter(ctx: RouterContext) {
   const clearSessionName = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         sessionId: z.string(),
       })
     )
@@ -1058,7 +1067,7 @@ export function createRouter(ctx: RouterContext) {
   const recordSessionAccess = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         sessionId: z.string(),
         agentType: z.enum(['claude-code', 'opencode', 'codex']),
       })
@@ -1071,7 +1080,7 @@ export function createRouter(ctx: RouterContext) {
   const deleteSession = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         sessionId: z.string(),
         agentType: z.enum(['claude-code', 'opencode', 'codex']),
       })
@@ -1138,7 +1147,7 @@ export function createRouter(ctx: RouterContext) {
   const searchSessions = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         query: z.string().min(1).max(500),
       })
     )
@@ -1355,7 +1364,7 @@ export function createRouter(ctx: RouterContext) {
     .input(
       z.object({
         agentType: z.enum(['claude-code', 'opencode']),
-        workspaceName: z.string().optional(),
+        workspaceName: AnyWorkspaceNameSchema.optional(),
       })
     )
     .handler(async ({ input }) => {
@@ -1416,7 +1425,7 @@ export function createRouter(ctx: RouterContext) {
   const listLiveSessions = os
     .input(
       z.object({
-        workspaceName: z.string().optional(),
+        workspaceName: AnyWorkspaceNameSchema.optional(),
       })
     )
     .handler(async ({ input }) => {
@@ -1463,7 +1472,7 @@ export function createRouter(ctx: RouterContext) {
   const startLiveSession = os
     .input(
       z.object({
-        workspaceName: z.string(),
+        workspaceName: AnyWorkspaceNameSchema,
         agentType: LiveAgentTypeSchema,
         sessionId: z.string().optional(),
         agentSessionId: z.string().optional(),

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+import { HOST_WORKSPACE_NAME } from './client-types';
+
+export const USER_WORKSPACE_NAME_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export function getUserWorkspaceNameError(rawName: string): string | null {
+  const name = rawName.trim();
+
+  if (name.length === 0) {
+    return 'Workspace name is required';
+  }
+
+  if (name === HOST_WORKSPACE_NAME) {
+    return 'Workspace name is reserved';
+  }
+
+  if (name.length > 63) {
+    return 'Workspace name must be 63 characters or less';
+  }
+
+  if (!USER_WORKSPACE_NAME_REGEX.test(name)) {
+    return 'Use lowercase letters, numbers, and hyphens; start/end with a letter or number';
+  }
+
+  return null;
+}
+
+export function isValidUserWorkspaceName(name: string): boolean {
+  return getUserWorkspaceNameError(name) === null;
+}
+
+export function isValidWorkspaceName(name: string, options: { allowHost?: boolean } = {}): boolean {
+  const trimmed = name.trim();
+
+  if (options.allowHost && trimmed === HOST_WORKSPACE_NAME) {
+    return true;
+  }
+
+  return isValidUserWorkspaceName(trimmed);
+}
+
+export function assertUserWorkspaceName(name: string): string {
+  const error = getUserWorkspaceNameError(name);
+  if (error) {
+    throw new Error(error);
+  }
+  return name.trim();
+}
+
+export function assertAnyWorkspaceName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed === HOST_WORKSPACE_NAME) {
+    return trimmed;
+  }
+  return assertUserWorkspaceName(trimmed);
+}
+
+export const UserWorkspaceNameSchema = z
+  .string()
+  .transform((value) => value.trim())
+  .superRefine((value, ctx) => {
+    const error = getUserWorkspaceNameError(value);
+    if (error) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: error });
+    }
+  });
+
+export const AnyWorkspaceNameSchema = z
+  .string()
+  .transform((value) => value.trim())
+  .superRefine((value, ctx) => {
+    if (value === HOST_WORKSPACE_NAME) {
+      return;
+    }
+
+    const error = getUserWorkspaceNameError(value);
+    if (error) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: error });
+    }
+  });

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -18,6 +18,7 @@ import {
 } from '../shared/constants';
 import { collectAuthorizedKeys, collectCopyKeys } from '../ssh/sync';
 import { syncAllAgents } from '../agents';
+import { assertUserWorkspaceName } from '../shared/workspace-name';
 
 async function findAvailablePort(start: number, end: number): Promise<number> {
   for (let port = start; port <= end; port++) {
@@ -373,6 +374,8 @@ export class WorkspaceManager {
   }
 
   async updateWorkerBinary(name: string): Promise<void> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -604,6 +607,8 @@ export class WorkspaceManager {
   }
 
   async get(name: string): Promise<Workspace | null> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       return null;
@@ -615,11 +620,13 @@ export class WorkspaceManager {
   }
 
   async touch(name: string): Promise<Workspace | null> {
+    name = assertUserWorkspaceName(name);
     return this.state.touchWorkspace(name);
   }
 
   async create(options: CreateWorkspaceOptions): Promise<Workspace> {
-    const { name, clone, env } = options;
+    const { name: rawName, clone, env } = options;
+    const name = assertUserWorkspaceName(rawName);
     const containerName = getContainerName(name);
     const volumeName = `${VOLUME_PREFIX}${name}`;
 
@@ -714,6 +721,8 @@ export class WorkspaceManager {
     name: string,
     options?: { clone?: string; env?: Record<string, string> }
   ): Promise<Workspace> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       return this.create({ name, clone: options?.clone, env: options?.env });
@@ -810,6 +819,8 @@ export class WorkspaceManager {
   }
 
   async stop(name: string): Promise<Workspace> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -831,6 +842,8 @@ export class WorkspaceManager {
   }
 
   async delete(name: string): Promise<void> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -871,6 +884,8 @@ export class WorkspaceManager {
   }
 
   async getLogs(name: string, tail = 100): Promise<string> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -881,6 +896,8 @@ export class WorkspaceManager {
   }
 
   async sync(name: string): Promise<void> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -896,6 +913,8 @@ export class WorkspaceManager {
   }
 
   async setPortForwards(name: string, forwards: PortMapping[]): Promise<Workspace> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -907,6 +926,8 @@ export class WorkspaceManager {
   }
 
   async getPortForwards(name: string): Promise<PortMapping[]> {
+    name = assertUserWorkspaceName(name);
+
     const workspace = await this.state.getWorkspace(name);
     if (!workspace) {
       throw new Error(`Workspace '${name}' not found`);
@@ -915,6 +936,9 @@ export class WorkspaceManager {
   }
 
   async clone(sourceName: string, cloneName: string): Promise<Workspace> {
+    sourceName = assertUserWorkspaceName(sourceName);
+    cloneName = assertUserWorkspaceName(cloneName);
+
     const source = await this.state.getWorkspace(sourceName);
     if (!source) {
       throw new Error(`Workspace '${sourceName}' not found`);

--- a/test/unit/workspace-name.test.ts
+++ b/test/unit/workspace-name.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { HOST_WORKSPACE_NAME } from '../../src/shared/client-types';
+import {
+  AnyWorkspaceNameSchema,
+  UserWorkspaceNameSchema,
+  getUserWorkspaceNameError,
+  isValidWorkspaceName,
+} from '../../src/shared/workspace-name';
+
+describe('workspace name validation', () => {
+  it('accepts typical workspace names', () => {
+    expect(getUserWorkspaceNameError('my-project')).toBeNull();
+    expect(getUserWorkspaceNameError('perrytest-ab12cd')).toBeNull();
+    expect(getUserWorkspaceNameError('0')).toBeNull();
+    expect(getUserWorkspaceNameError('a1-b2')).toBeNull();
+  });
+
+  it('rejects empty or whitespace-only names', () => {
+    expect(getUserWorkspaceNameError('')).toBe('Workspace name is required');
+    expect(getUserWorkspaceNameError('   ')).toBe('Workspace name is required');
+  });
+
+  it('rejects invalid characters and shapes', () => {
+    expect(getUserWorkspaceNameError('My-Project')).toBeTruthy();
+    expect(getUserWorkspaceNameError('my_project')).toBeTruthy();
+    expect(getUserWorkspaceNameError('my.project')).toBeTruthy();
+    expect(getUserWorkspaceNameError('my/project')).toBeTruthy();
+    expect(getUserWorkspaceNameError('-start')).toBeTruthy();
+    expect(getUserWorkspaceNameError('end-')).toBeTruthy();
+  });
+
+  it('rejects overly long names', () => {
+    const tooLong = 'a'.repeat(64);
+    expect(getUserWorkspaceNameError(tooLong)).toBe('Workspace name must be 63 characters or less');
+  });
+
+  it('rejects the reserved host workspace name for user workspaces', () => {
+    expect(getUserWorkspaceNameError(HOST_WORKSPACE_NAME)).toBe('Workspace name is reserved');
+    expect(UserWorkspaceNameSchema.safeParse(HOST_WORKSPACE_NAME).success).toBe(false);
+  });
+
+  it('allows the host workspace name when explicitly permitted', () => {
+    expect(isValidWorkspaceName(HOST_WORKSPACE_NAME, { allowHost: true })).toBe(true);
+    expect(AnyWorkspaceNameSchema.safeParse(HOST_WORKSPACE_NAME).success).toBe(true);
+  });
+});

--- a/web/src/pages/WorkspaceDetail.tsx
+++ b/web/src/pages/WorkspaceDetail.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react'
 import { api, type SessionInfo, type AgentType, type PortMapping } from '@/lib/api'
 import { HOST_WORKSPACE_NAME } from '@shared/client-types'
+import { getUserWorkspaceNameError } from '@shared/workspace-name'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -406,6 +407,10 @@ export function WorkspaceDetail() {
   const [showCloneDialog, setShowCloneDialog] = useState(false)
   const [cloneName, setCloneName] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
+
+  const trimmedCloneName = cloneName.trim()
+  const cloneNameError = trimmedCloneName ? getUserWorkspaceNameError(trimmedCloneName) : null
+  const canClone = trimmedCloneName.length > 0 && !cloneNameError
   const [debouncedQuery, setDebouncedQuery] = useState('')
 
   useEffect(() => {
@@ -1242,6 +1247,7 @@ export function WorkspaceDetail() {
               autoComplete="off"
               data-testid="clone-name-input"
             />
+            {cloneNameError && <p className="text-sm text-destructive mt-2">{cloneNameError}</p>}
             {cloneMutation.error && (
               <p className="text-sm text-destructive mt-2">
                 {(cloneMutation.error as Error).message || 'Clone failed'}
@@ -1252,11 +1258,11 @@ export function WorkspaceDetail() {
             <AlertDialogCancel onClick={() => setShowCloneDialog(false)}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
-                if (cloneName.trim()) {
-                  cloneMutation.mutate(cloneName.trim())
+                if (canClone) {
+                  cloneMutation.mutate(trimmedCloneName)
                 }
               }}
-              disabled={!cloneName.trim() || cloneMutation.isPending}
+              disabled={!canClone || cloneMutation.isPending}
             >
               {cloneMutation.isPending ? (
                 <>


### PR DESCRIPTION
## Summary
- Add shared workspace name validator and Zod schemas
- Enforce validation in agent RPC routes and websocket upgrade path
- Validate workspace name inputs in web + mobile create/clone flows
- Add unit tests for workspace name rules

## Why
Prevents invalid workspace names from producing invalid Docker resources/URLs and ensures consistent behavior across clients.

## Testing
- `bun run validate:core`
- `bun run build:web`
- `bun run lint:web` (warnings only)