### PR TITLE
fix: opencode prompt_async model payload

### DIFF
--- a/src/session-manager/adapters/opencode.ts
+++ b/src/session-manager/adapters/opencode.ts
@@ -32,6 +32,26 @@ interface OpenCodeServerEvent {
 const MESSAGE_TIMEOUT_MS = 30000;
 const SSE_TIMEOUT_MS = 10 * 60 * 1000;
 
+type OpenCodeModelParam = {
+  providerID: string;
+  modelID: string;
+};
+
+export function toOpenCodeModelParam(model: string): OpenCodeModelParam | null {
+  const trimmed = model.trim();
+  if (!trimmed) return null;
+
+  const slashIndex = trimmed.indexOf('/');
+  if (slashIndex === -1) return null;
+
+  const providerID = trimmed.slice(0, slashIndex);
+  const modelID = trimmed.slice(slashIndex + 1);
+
+  if (!providerID || !modelID) return null;
+
+  return { providerID, modelID };
+}
+
 export class OpenCodeAdapter implements AgentAdapter {
   readonly agentType = 'opencode' as const;
 
@@ -223,7 +243,10 @@ export class OpenCodeAdapter implements AgentAdapter {
 
     const payload: Record<string, unknown> = { parts: [{ type: 'text', text: message }] };
     if (this.model) {
-      payload.model = this.model;
+      const parsedModel = toOpenCodeModelParam(this.model);
+      if (parsedModel) {
+        payload.model = parsedModel;
+      }
     }
 
     if (this.isHost) {

--- a/test/session-manager/opencode-adapter.test.ts
+++ b/test/session-manager/opencode-adapter.test.ts
@@ -83,7 +83,7 @@ describe('OpenCodeAdapter protocol', () => {
     );
     expect(promptCall).toBeTruthy();
     expect(promptCall?.json).toMatchObject({
-      model: 'opencode/gpt-5.1-codex',
+      model: { providerID: 'opencode', modelID: 'gpt-5.1-codex' },
       parts: [{ type: 'text', text: 'hello' }],
     });
   });

--- a/test/unit/opencode-adapter-model.test.ts
+++ b/test/unit/opencode-adapter-model.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { toOpenCodeModelParam } from '../../src/session-manager/adapters/opencode';
+
+describe('toOpenCodeModelParam', () => {
+  test('parses provider/model pair', () => {
+    expect(toOpenCodeModelParam('opencode/claude-opus-4-5')).toEqual({
+      providerID: 'opencode',
+      modelID: 'claude-opus-4-5',
+    });
+  });
+
+  test('parses provider/model pair with extra whitespace', () => {
+    expect(toOpenCodeModelParam('  google-vertex/gemini-2.5-pro  ')).toEqual({
+      providerID: 'google-vertex',
+      modelID: 'gemini-2.5-pro',
+    });
+  });
+
+  test('returns null when missing provider prefix', () => {
+    expect(toOpenCodeModelParam('sonnet')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(toOpenCodeModelParam('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Fix OpenCode chat 400s by sending the model field as an object ({ providerID, modelID }) instead of a string.
- Add unit coverage for model string parsing and update the existing adapter protocol test.

## Context
Recent OpenCode versions validate model as an object and return 400 when given a string like opencode/claude-opus-4-5. This broke Perry OpenCode chat connections.

## Testing
- bun run validate:core