### PR TITLE
fix: align CLI --clone with web UI by using createWorkspace directly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,8 +208,18 @@ program
       console.log(`Starting workspace '${name}'...`);
 
       let workspace;
-      // Check if workspace exists first
-      const existingWorkspace = await client.getWorkspace(name).catch(() => null);
+      // Check if workspace exists first - only treat NOT_FOUND as "doesn't exist"
+      let existingWorkspace = null;
+      try {
+        existingWorkspace = await client.getWorkspace(name);
+      } catch (err) {
+        if (err instanceof ApiClientError && err.code === 'NOT_FOUND') {
+          // Workspace doesn't exist, which is fine - we'll create it
+        } else {
+          // Network errors, timeouts, etc. should be re-thrown
+          throw err;
+        }
+      }
 
       if (!existingWorkspace) {
         // Workspace doesn't exist - use createWorkspace (same as web UI)


### PR DESCRIPTION
## Summary

- Fixes the `--clone` flag not working when using `perry start <name> --clone <url>` from the CLI
- Aligns CLI behavior with web/mobile UI by calling `createWorkspace()` directly for new workspaces
- Adds a warning when `--clone` is used on an existing workspace (where it would be ignored)

## Problem

The CLI was using `startWorkspace()` which internally checks if a workspace exists and then calls `create()`. The web UI calls `createWorkspace()` directly. This bifurcation could cause the clone option to not work correctly from the CLI.

## Solution

The CLI now:
1. Checks if the workspace exists first via `getWorkspace()`
2. If it doesn't exist: calls `createWorkspace()` (same path as web UI)
3. If it exists: calls `startWorkspace()` and warns that `--clone` is ignored