### PR TITLE
feat: add Perry agent skill for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Continue your sessions from any device on your tailnet.
 
 Perry is not endorsing or associated with any crypto tokens or meme coins. If you'd like to support the project, the best way is to donate to your favorite charity, or to St. Jude: https://www.stjude.org/donate/donate-to-st-jude.html
 
+Agent Skill: [skills/perry/SKILL.md](skills/perry/SKILL.md)
+
 ## Features
 
 - **AI Coding Agents** - Claude Code, OpenCode, Codex CLI pre-installed

--- a/docs/docs/agents.md
+++ b/docs/docs/agents.md
@@ -32,6 +32,10 @@ The Sessions tab is a history and shortcut list. Opening a session drops you int
 - [OpenCode Workflow](./workflows/opencode.md)
 - [Claude Code and Codex Workflow](./workflows/claude-code.md)
 
+## Perry skill
+
+There is a command-focused Agent Skill available at `skills/perry/SKILL.md` and documented in [Skills](./skills.md).
+
 ## Configure agents
 
 Set OpenCode server defaults in the Web UI (Settings > Agents), use the setup wizard, or edit `config.json` directly. See [Configuration: Agents](./configuration/agents.md).

--- a/docs/docs/skills.md
+++ b/docs/docs/skills.md
@@ -1,0 +1,20 @@
+---
+sidebar_position: 7
+---
+
+# Skills
+
+Perry includes an Agent Skill you can use to onboard assistants to Perry workflows.
+
+- Skill file: `skills/perry/SKILL.md`
+
+The skill is concise and command-focused with expected behavior and gotchas. It covers:
+
+- Installing and running the Perry agent
+- Creating and connecting to workspaces over your tailnet
+- OpenCode attach flow over `http://<workspace>:4096`
+- Claude Code usage inside workspace shells
+- SSH access and key syncing
+- Common commands and troubleshooting
+
+If you are using a skills system that supports Agent Skills, load the file directly from the repo.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -8,7 +8,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Core Tasks',
-      items: ['workspaces', 'connect', 'agents', 'networking', 'sync-update'],
+      items: ['workspaces', 'connect', 'agents', 'skills', 'networking', 'sync-update'],
     },
     {
       type: 'category',

--- a/skills/perry/SKILL.md
+++ b/skills/perry/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: perry
+description: Create and manage isolated Docker workspaces on your tailnet with Claude Code and OpenCode pre-installed. Use when working with Perry workspaces, connecting to coding agents, or managing remote development environments.
+---
+
+# Perry Usage
+
+Perry runs a local agent that creates isolated Docker workspaces and advertises them on your tailnet. Each workspace has coding agents preinstalled and is reachable via CLI, web UI, or SSH.
+
+## Quick start
+
+```bash
+# Install
+curl -fsSL https://raw.githubusercontent.com/gricha/perry/main/install.sh | bash
+
+# Run the agent
+perry agent run
+
+# Point your CLI at the agent (one-time)
+perry config agent <hostname>
+
+# Create a workspace (optional clone)
+perry start my-proj --clone git@github.com:user/repo.git
+
+# Shell into it
+perry shell my-proj
+```
+
+Expected behavior:
+- `perry agent run` starts a local daemon.
+- `perry start` creates a `workspace-my-proj` container and registers it on your tailnet.
+- `perry shell` opens an interactive shell inside the workspace.
+
+## OpenCode workflow
+
+```bash
+# Attach via CLI
+opencode attach http://my-proj:4096
+```
+
+Expected behavior:
+- OpenCode is reachable at `http://<workspace>:4096` from any device on the tailnet.
+- You can open the same URL in a browser.
+
+Gotchas:
+- If `:4096` is unreachable, verify tailnet connectivity and that the workspace is running.
+
+## Claude Code workflow
+
+```bash
+# Run from a workspace shell
+perry shell my-proj
+claude
+```
+
+Expected behavior:
+- Claude Code runs inside the workspace shell.
+- Remote access to the workspace shell can be done via Perry web UI or a mobile terminal app.
+
+Gotchas:
+- You do not attach to Claude Code over HTTP; use it inside the workspace shell.
+
+## SSH access
+
+```bash
+ssh workspace-my-proj
+```
+
+Expected behavior:
+- The workspace inherits authorized keys from the host.
+- If your key works on the host, it should work on the workspace.
+
+Gotchas:
+- If SSH fails, ensure your host keys exist and the workspace is on the tailnet.
+
+## Common commands
+
+```bash
+# List workspaces
+perry list
+
+# Stop a workspace
+perry stop my-proj
+
+# Remove a workspace
+perry remove my-proj
+```
+
+## Troubleshooting
+
+- Workspace not reachable: confirm Tailscale is running and the workspace name resolves.
+- Port conflicts: if you changed ports, update your attach URL.
+- Slow start: workspace setup can take time; check the web UI for startup progress.
+
+## Naming conventions
+
+- Containers are `workspace-<name>`.
+- Internal resources use `workspace-internal-<name>`.
+
+## References
+
+- Getting Started: https://gricha.github.io/perry/docs/getting-started
+- OpenCode workflow: https://gricha.github.io/perry/docs/workflows/opencode
+- Claude Code workflow: https://gricha.github.io/perry/docs/workflows/claude-code


### PR DESCRIPTION
## Summary

- Add agent skill at `skills/perry/SKILL.md` following Anthropic's skill format
- Covers Perry workflows: workspace creation, OpenCode attach, Claude Code shell, SSH access
- Uses action-oriented description with trigger keywords for proper skill discovery
- Includes "Expected behavior" and "Gotchas" sections for each workflow