### PR TITLE
fix: use perry shell instead of invalid perry ssh command in docs

### DIFF
--- a/skills/perry/SKILL.md
+++ b/skills/perry/SKILL.md
@@ -63,14 +63,16 @@ Gotchas:
 ## SSH access
 
 ```bash
-ssh workspace-my-proj
+ssh workspace@my-proj
 ```
 
 Expected behavior:
+- The username is `workspace` and the hostname is the workspace name (e.g., `my-proj`).
 - The workspace inherits authorized keys from the host.
 - If your key works on the host, it should work on the workspace.
 
 Gotchas:
+- The SSH username is `workspace`, not part of the hostname. Use `ssh workspace@<name>`, not `ssh workspace-<name>`.
 - If SSH fails, ensure your host keys exist and the workspace is on the tailnet.
 
 ## Common commands


### PR DESCRIPTION
Found by Clawdius the Crab 🦀

The docs had `perry ssh myworkspace` which is invalid - `perry ssh` is a subcommand group for SSH key management, not for connecting to workspaces.

Changed to `perry shell myworkspace` which is the correct CLI command.

Also clarified in external docs that the SSH username is always `workspace` (e.g., `ssh workspace@myproject`).