### PR TITLE
fix: add opencode to SSH SetEnv PATH

### DIFF
--- a/perry/Dockerfile.base
+++ b/perry/Dockerfile.base
@@ -109,7 +109,7 @@ RUN mkdir -p /run/sshd \
   && sed -i 's/#\?AllowTcpForwarding.*/AllowTcpForwarding yes/' /etc/ssh/sshd_config \
   && sed -i 's/#\?AllowAgentForwarding.*/AllowAgentForwarding yes/' /etc/ssh/sshd_config \
   && sed -i 's/#\?GatewayPorts.*/GatewayPorts clientspecified/' /etc/ssh/sshd_config \
-  && echo 'SetEnv PATH=/home/workspace/.npm-global/bin:/home/workspace/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' >> /etc/ssh/sshd_config
+  && echo 'SetEnv PATH=/home/workspace/.opencode/bin:/home/workspace/.npm-global/bin:/home/workspace/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' >> /etc/ssh/sshd_config
 
 # Install Node.js (needed for npm global packages like codex)
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \


### PR DESCRIPTION
## Summary

- Add /home/workspace/.opencode/bin to sshd_config SetEnv PATH
- Fixes issue where non-login SSH sessions (e.g., `ssh workspace@name "command"`) could not find opencode

Without this, SSH commands had to use the full path:
```bash
# Before (broken)
ssh workspace@foo "opencode run ..."

# After (works)
ssh workspace@foo "opencode run ..."
```
