### PR TITLE
fix: use shorter tokens without prefix

### DIFF
--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -667,13 +667,13 @@ export function createRouter(ctx: RouterContext) {
     const token = config.auth?.token;
     return {
       hasToken: !!token,
-      tokenPreview: token ? `${token.slice(0, 10)}...${token.slice(-4)}` : undefined,
+      tokenPreview: token ? `${token.slice(0, 4)}...${token.slice(-4)}` : undefined,
     };
   });
 
   const generateAuthToken = os.output(z.object({ token: z.string() })).handler(async () => {
     const currentConfig = ctx.config.get();
-    const token = `perry-${crypto.randomBytes(16).toString('hex')}`;
+    const token = crypto.randomBytes(12).toString('hex');
     const newConfig = { ...currentConfig, auth: { ...currentConfig.auth, token } };
     ctx.config.set(newConfig);
     await saveAgentConfig(newConfig, ctx.configDir);

--- a/src/agent/run.ts
+++ b/src/agent/run.ts
@@ -269,7 +269,7 @@ async function ensureAuthForNewInstalls(configDir: string): Promise<AgentConfig>
   const config = await loadAgentConfig(configDir);
 
   if (!configExists && !config.auth?.token) {
-    const token = `perry-${crypto.randomBytes(16).toString('hex')}`;
+    const token = crypto.randomBytes(12).toString('hex');
     config.auth = { ...config.auth, token };
     await saveAgentConfig(config, configDir);
 

--- a/src/cli/setup-wizard.tsx
+++ b/src/cli/setup-wizard.tsx
@@ -360,7 +360,7 @@ function SetupWizard() {
   };
 
   const generateAuthToken = () => {
-    const token = `perry-${crypto.randomBytes(16).toString('hex')}`;
+    const token = crypto.randomBytes(12).toString('hex');
     setState((s) => ({
       ...s,
       authToken: token,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -11,7 +11,7 @@ export async function authInit(): Promise<void> {
     return;
   }
 
-  const token = `perry-${crypto.randomBytes(16).toString('hex')}`;
+  const token = crypto.randomBytes(12).toString('hex');
   config.auth = { ...config.auth, token };
   await saveAgentConfig(config, configDir);
 


### PR DESCRIPTION
## Summary

- Remove `perry-` prefix from generated tokens
- Use 12 bytes (24 hex chars) instead of 16 bytes (was 39 chars total with prefix)
- Adjust token preview in API to show `xxxx...xxxx` instead of `xxxxxxxxxx...xxxx`

🤖 Generated with [Claude Code](https://claude.ai/code)