### PR TITLE
chore: migrate warden.toml to [[skills]] format

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -1,34 +1,40 @@
 version = 1
 
-[defaults.filters]
+[defaults]
 ignorePaths = ["docs/**", "**/*.md", "**/*.lock", "**/*.json"]
 
-[[triggers]]
+[[skills]]
 name = "security-review"
-event = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-skill = "security-review"
+paths = ["src/**", "web/**", "mobile/**"]
 remote = "getsentry/skills"
 
-[triggers.filters]
-paths = ["src/**", "web/**", "mobile/**"]
-
-[[triggers]]
-name = "react-best-practices"
-event = "pull_request"
+[[skills.triggers]]
+type = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
-skill = "vercel-react-best-practices"
+
+[[skills.triggers]]
+type = "local"
+
+[[skills]]
+name = "react-best-practices"
+paths = ["**/*.tsx", "**/*.jsx"]
 remote = "vercel-labs/agent-skills"
 
-[triggers.filters]
-paths = ["**/*.tsx", "**/*.jsx"]
-
-[[triggers]]
-name = "code-simplifier"
-event = "pull_request"
+[[skills.triggers]]
+type = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
-skill = "code-simplifier"
+
+[[skills.triggers]]
+type = "local"
+
+[[skills]]
+name = "code-simplifier"
+paths = ["src/**", "web/**", "mobile/**"]
 remote = "getsentry/skills"
 
-[triggers.filters]
-paths = ["src/**", "web/**", "mobile/**"]
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills.triggers]]
+type = "local"


### PR DESCRIPTION
## Summary
- Migrate from legacy `[[triggers]]` format to current `[[skills]]` format
- Add `type = "local"` triggers so skills also run via `warden` CLI (not just on PRs)
- No behavior change for PR workflow -- same skills, same paths, same actions

## Before
```toml
[[triggers]]
name = "security-review"
event = "pull_request"
actions = ["opened", "synchronize", "reopened"]
skill = "security-review"
remote = "getsentry/skills"

[triggers.filters]
paths = ["src/**", "web/**", "mobile/**"]
```

## After
```toml
[[skills]]
name = "security-review"
paths = ["src/**", "web/**", "mobile/**"]
remote = "getsentry/skills"

[[skills.triggers]]
type = "pull_request"
actions = ["opened", "synchronize", "reopened"]

[[skills.triggers]]
type = "local"
```

## Test plan
- [ ] Warden GitHub Action runs on this PR and matches the same triggers
- [ ] `warden HEAD` from CLI picks up local triggers