### PR TITLE
fix: correct warden skill name and add find-bugs

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -16,9 +16,21 @@ actions = ["opened", "synchronize", "reopened"]
 type = "local"
 
 [[skills]]
-name = "react-best-practices"
+name = "vercel-react-best-practices"
 paths = ["**/*.tsx", "**/*.jsx"]
 remote = "vercel-labs/agent-skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills.triggers]]
+type = "local"
+
+[[skills]]
+name = "find-bugs"
+paths = ["src/**", "web/**", "mobile/**"]
+remote = "getsentry/skills"
 
 [[skills.triggers]]
 type = "pull_request"


### PR DESCRIPTION
## Summary

- Fix `react-best-practices` -> `vercel-react-best-practices` to match the actual remote skill name in vercel-labs/agent-skills
- Add `find-bugs` skill from getsentry/skills for PR and local analysis