### PR TITLE
feat: rootless Podman support

### DIFF
--- a/docs/docs/podman.md
+++ b/docs/docs/podman.md
@@ -1,0 +1,169 @@
+---
+sidebar_position: 10
+---
+
+# Podman Support
+
+Perry supports running with Podman as an alternative to Docker. This allows you to use Perry in environments where Podman is preferred or required.
+
+## Overview
+
+When using Podman, Perry workspaces connect to an external container engine instead of running Docker-in-Docker. This is achieved through a podman-in-podman sidecar pattern where the workspace container connects to the host's Podman socket.
+
+## Prerequisites
+
+- **Podman** - [Install Podman](https://podman.io/getting-started/installation)
+- **Podman socket enabled** - Required for container management
+- **macOS or Linux** - Windows via WSL2
+
+Verify Podman is running:
+
+```bash
+podman info
+```
+
+Enable the Podman socket:
+
+```bash
+# On systemd-based systems
+systemctl --user enable --now podman.socket
+
+# Verify socket is running
+systemctl --user status podman.socket
+```
+
+## Configuration
+
+Add the `runtime` field to your Perry configuration file (`~/.perry/config.json`):
+
+```json
+{
+  "runtime": "podman",
+  "port": 7391,
+  "host": "0.0.0.0",
+  "credentials": {
+    "env": {},
+    "files": {}
+  },
+  "scripts": {
+    "post_start": [],
+    "fail_on_error": false
+  }
+}
+```
+
+The `runtime` field accepts two values:
+- `"docker"` (default) - Use Docker with Docker-in-Docker
+- `"podman"` - Use external Podman engine
+
+## Building the Workspace Image
+
+When building a workspace image for Podman, use the `RUNTIME` build argument:
+
+```bash
+# Build for Podman
+podman build \
+  --build-arg RUNTIME=podman \
+  -t perry-workspace:podman \
+  -f perry/Dockerfile.base \
+  .
+
+# Build for Docker (default)
+docker build \
+  -t perry-workspace:latest \
+  -f perry/Dockerfile.base \
+  .
+```
+
+The `RUNTIME=podman` build argument:
+- Skips Docker CE installation
+- Omits containerd.io and Docker plugins
+- Sets `DOCKER_HOST=tcp://host.containers.internal:2375` environment variable
+
+## Podman-in-Podman Sidecar Pattern
+
+Perry workspaces running with Podman use an external container engine. The workspace container connects to the host's Podman socket through the `DOCKER_HOST` environment variable.
+
+### Container Creation
+
+When `runtime: "podman"` is configured, Perry:
+- Does NOT set `privileged: true` on workspace containers
+- Skips the Docker-in-Docker volume (`workspace-name-docker` → `/var/lib/docker`)
+- Relies on `DOCKER_HOST` for container operations
+
+### Entrypoint Behavior
+
+The workspace entrypoint (`perry/internal/src/commands/entrypoint.ts`) checks for the `DOCKER_HOST` environment variable:
+- If set: Skips `ensureDockerd()` and `waitForDocker()`
+- If not set: Starts Docker daemon as normal (Docker-in-Docker)
+
+All other initialization (SSH, Tailscale, user scripts) proceeds normally.
+
+## Networking
+
+When using Podman, ensure the workspace container can reach the host's Podman socket:
+
+```bash
+# Start workspace with host network access
+podman run \
+  --network slirp4netns:allow_host_loopback=true \
+  ...
+```
+
+Or expose the Podman socket on a TCP port:
+
+```bash
+# Expose Podman socket on TCP (development only)
+podman system service --time=0 tcp:0.0.0.0:2375
+```
+
+**Security Note**: Exposing the Podman socket on TCP without authentication is insecure. Use this only in trusted development environments.
+
+## Differences from Docker
+
+| Feature | Docker | Podman |
+|---------|--------|--------|
+| Privileged mode | Required | Not used |
+| Docker-in-Docker volume | Created | Skipped |
+| Container engine | Internal (dind) | External (host) |
+| Socket location | `/var/run/docker.sock` | Via `DOCKER_HOST` |
+
+## Troubleshooting
+
+### Workspace can't connect to Podman
+
+Check that `DOCKER_HOST` is set correctly:
+
+```bash
+perry exec <workspace-name> -- env | grep DOCKER_HOST
+```
+
+Verify the Podman socket is accessible:
+
+```bash
+podman system connection list
+```
+
+### Permission denied errors
+
+Ensure the workspace user has access to the Podman socket. You may need to adjust socket permissions or run Podman in rootless mode.
+
+### Container operations fail
+
+Check Podman logs:
+
+```bash
+journalctl --user -u podman.socket -f
+```
+
+## Limitations
+
+- Docker Compose may have compatibility issues with Podman
+- Some Docker-specific features may not work identically
+- Performance characteristics differ from Docker-in-Docker
+
+## Next Steps
+
+- [Workspaces](./workspaces.md) - Learn about workspace management
+- [Configuration](./configuration/overview.md) - Advanced configuration options
+- [Troubleshooting](./troubleshooting.md) - Common issues and solutions

--- a/perry/Dockerfile.base
+++ b/perry/Dockerfile.base
@@ -5,6 +5,8 @@
 
 FROM ubuntu:noble
 
+ARG RUNTIME=docker
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites for adding Docker repository
@@ -15,20 +17,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsb-release \
   && rm -rf /var/lib/apt/lists/*
 
-# Add Docker's official GPG key and repository
-RUN install -m 0755 -d /etc/apt/keyrings \
-  && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
-  && chmod a+r /etc/apt/keyrings/docker.asc \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+# Add Docker's official GPG key and repository (only for docker runtime)
+RUN if [ "$RUNTIME" = "docker" ]; then \
+      install -m 0755 -d /etc/apt/keyrings \
+      && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+      && chmod a+r /etc/apt/keyrings/docker.asc \
+      && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+      $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null; \
+    fi
 
-# Install Docker Engine, CLI, and essential tools
+# Install Docker Engine, CLI, and essential tools (conditionally install Docker packages)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-buildx-plugin \
-    docker-compose-plugin \
+    $(if [ "$RUNTIME" = "docker" ]; then echo "docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"; fi) \
     bash \
     sudo \
     openssh-server \
@@ -101,11 +101,16 @@ ENV BUN_INSTALL=/usr/local
 RUN bash -lc "curl -fsSL https://bun.sh/install | bash" \
   && bun --version
 
+# Set DOCKER_HOST for podman runtime (external container engine)
+RUN if [ "$RUNTIME" = "podman" ]; then \
+      echo "ENV DOCKER_HOST=tcp://host.containers.internal:2375" >> /etc/environment; \
+    fi
+
 # Create workspace user with passwordless sudo
 RUN useradd -m -s /bin/bash workspace \
   && echo "workspace:workspace" | chpasswd \
   && usermod -aG sudo workspace \
-  && usermod -aG docker workspace \
+  && (getent group docker && usermod -aG docker workspace || true) \
   && echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Configure npm to use user-writable global directory

--- a/perry/internal/src/commands/entrypoint.ts
+++ b/perry/internal/src/commands/entrypoint.ts
@@ -14,13 +14,21 @@ export const runEntrypoint = async () => {
   } catch (error) {
     console.log(`[entrypoint] Failed to add SSH key (non-fatal): ${(error as Error).message}`);
   }
-  console.log("[entrypoint] Starting Docker daemon...");
-  ensureDockerd();
-  const ready = await waitForDocker();
-  if (!ready) {
-    process.exit(1);
-    return;
+
+  // Skip Docker daemon setup if DOCKER_HOST is set (external container engine)
+  const useExternalDocker = !!process.env.DOCKER_HOST;
+  if (!useExternalDocker) {
+    console.log("[entrypoint] Starting Docker daemon...");
+    ensureDockerd();
+    const ready = await waitForDocker();
+    if (!ready) {
+      process.exit(1);
+      return;
+    }
+  } else {
+    console.log("[entrypoint] Using external container engine at DOCKER_HOST");
   }
+
   console.log("[entrypoint] Running workspace initialization as workspace user...");
   try {
     await runCommand("sudo", ["-u", "workspace", "-E", "/usr/local/bin/workspace-internal", "init"], {
@@ -44,5 +52,12 @@ export const runEntrypoint = async () => {
     await waitForTailscaled();
   }
   void monitorServices();
-  await tailDockerdLogs();
+
+  // Skip tailing dockerd logs if using external container engine
+  if (!useExternalDocker) {
+    await tailDockerdLogs();
+  } else {
+    // Keep process alive for external container engine mode
+    await new Promise(() => {});
+  }
 };

--- a/perry/internal/src/lib/services.ts
+++ b/perry/internal/src/lib/services.ts
@@ -49,9 +49,10 @@ const isProcessRunning = async (name: string) => {
 export const monitorServices = async () => {
   console.log("[entrypoint] Starting service monitor...");
   const hasTailscale = !!process.env.TS_AUTHKEY;
+  const useExternalDocker = !!process.env.DOCKER_HOST;
   while (true) {
     await delay(10000);
-    if (!(await isProcessRunning("dockerd"))) {
+    if (!useExternalDocker && !(await isProcessRunning("dockerd"))) {
       console.log("[entrypoint] Restarting Docker daemon...");
       startDockerd();
       await delay(2000);

--- a/src/agent/router.ts
+++ b/src/agent/router.ts
@@ -240,7 +240,9 @@ export function createRouter(ctx: RouterContext) {
       if (workspace.status === 'running') {
         try {
           const containerName = getContainerName(input.name);
-          const client = await createWorkerClient(containerName);
+          const client = await createWorkerClient(containerName, {
+            runtime: ctx.config.get().runtime,
+          });
           const health = await client.health();
           workerVersion = health.version;
         } catch {
@@ -951,8 +953,9 @@ export function createRouter(ctx: RouterContext) {
     }
 
     const containerName = `workspace-${input.workspaceName}`;
+    const runtime = ctx.config.get().runtime;
 
-    const rawSessions = await discoverAllSessions(containerName, execInContainer);
+    const rawSessions = await discoverAllSessions(containerName, execInContainer, runtime);
 
     const customNames = await getSessionNamesForWorkspace(ctx.stateDir, input.workspaceName);
 
@@ -973,7 +976,7 @@ export function createRouter(ctx: RouterContext) {
 
     const detailsResults = await Promise.all(
       paginatedRawSessions.map((rawSession) =>
-        getAgentSessionDetails(containerName, rawSession, execInContainer)
+        getAgentSessionDetails(containerName, rawSession, execInContainer, runtime)
       )
     );
 
@@ -1057,15 +1060,17 @@ export function createRouter(ctx: RouterContext) {
           ? toClientAgentType(record.agentType)
           : input.agentType;
 
+        const runtime = ctx.config.get().runtime;
         result = resolvedAgentType
           ? await getSessionMessages(
               containerName,
               agentSessionId,
               resolvedAgentType,
               execInContainer,
-              input.projectPath
+              input.projectPath,
+              runtime
             )
-          : await findSessionMessages(containerName, agentSessionId, execInContainer);
+          : await findSessionMessages(containerName, agentSessionId, execInContainer, runtime);
 
         if (result && !record) {
           const agentType = toRegistryAgentType(result.agentType || resolvedAgentType);
@@ -1201,6 +1206,7 @@ export function createRouter(ctx: RouterContext) {
       }
 
       const containerName = `workspace-${input.workspaceName}`;
+      const runtime = ctx.config.get().runtime;
 
       const record = await resolveSessionRecord(input.sessionId);
       const agentSessionId = record?.agentSessionId || input.sessionId;
@@ -1209,7 +1215,8 @@ export function createRouter(ctx: RouterContext) {
         containerName,
         agentSessionId,
         agentType,
-        execInContainer
+        execInContainer,
+        runtime
       );
 
       if (!result.success) {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -102,6 +102,7 @@ export async function loadAgentConfig(configDir?: string): Promise<AgentConfig> 
       },
       skills: Array.isArray(config.skills) ? config.skills : [],
       mcpServers: Array.isArray(config.mcpServers) ? config.mcpServers : [],
+      runtime: config.runtime || 'docker',
       allowHostAccess: config.allowHostAccess ?? true,
       ssh: {
         autoAuthorizeHostKeys: config.ssh?.autoAuthorizeHostKeys ?? true,

--- a/src/sessions/agents/index.ts
+++ b/src/sessions/agents/index.ts
@@ -27,17 +27,19 @@ const _providers: Record<AgentType, AgentSessionProvider> = {
 
 export async function discoverAllSessions(
   containerName: string,
-  _exec: ExecInContainer
+  _exec: ExecInContainer,
+  runtime?: 'docker' | 'podman'
 ): Promise<RawSession[]> {
-  return discoverSessionsViaWorker(containerName);
+  return discoverSessionsViaWorker(containerName, runtime);
 }
 
 export async function getSessionDetails(
   containerName: string,
   rawSession: RawSession,
-  _exec: ExecInContainer
+  _exec: ExecInContainer,
+  runtime?: 'docker' | 'podman'
 ): Promise<SessionListItem | null> {
-  return getSessionDetailsViaWorker(containerName, rawSession);
+  return getSessionDetailsViaWorker(containerName, rawSession, runtime);
 }
 
 export async function getSessionMessages(
@@ -45,9 +47,10 @@ export async function getSessionMessages(
   sessionId: string,
   agentType: AgentType,
   _exec: ExecInContainer,
-  _projectPath?: string
+  _projectPath?: string,
+  runtime?: 'docker' | 'podman'
 ): Promise<{ id: string; agentType: AgentType; messages: SessionMessage[] } | null> {
-  const result = await getSessionMessagesViaWorker(containerName, sessionId);
+  const result = await getSessionMessagesViaWorker(containerName, sessionId, runtime);
   if (!result) return null;
   return { ...result, agentType };
 }
@@ -55,10 +58,11 @@ export async function getSessionMessages(
 export async function findSessionMessages(
   containerName: string,
   sessionId: string,
-  _exec: ExecInContainer
+  _exec: ExecInContainer,
+  runtime?: 'docker' | 'podman'
 ): Promise<{ id: string; agentType: AgentType; messages: SessionMessage[] } | null> {
   const { createWorkerClient } = await import('../../worker/client');
-  const client = await createWorkerClient(containerName);
+  const client = await createWorkerClient(containerName, { runtime });
 
   const session = await client.getSession(sessionId);
   if (!session) {
@@ -87,9 +91,10 @@ export async function deleteSession(
   containerName: string,
   sessionId: string,
   _agentType: AgentType,
-  _exec: ExecInContainer
+  _exec: ExecInContainer,
+  runtime?: 'docker' | 'podman'
 ): Promise<{ success: boolean; error?: string }> {
-  return deleteSessionViaWorker(containerName, sessionId);
+  return deleteSessionViaWorker(containerName, sessionId, runtime);
 }
 
 export interface SearchResult {

--- a/src/sessions/agents/worker-provider.ts
+++ b/src/sessions/agents/worker-provider.ts
@@ -4,17 +4,24 @@ import { createWorkerClient, type WorkerClient } from '../../worker/client';
 
 const clientCache = new Map<string, WorkerClient>();
 
-async function getWorkerClient(containerName: string): Promise<WorkerClient> {
-  let client = clientCache.get(containerName);
+async function getWorkerClient(
+  containerName: string,
+  runtime?: 'docker' | 'podman'
+): Promise<WorkerClient> {
+  const cacheKey = `${containerName}:${runtime || 'docker'}`;
+  let client = clientCache.get(cacheKey);
   if (!client) {
-    client = await createWorkerClient(containerName);
-    clientCache.set(containerName, client);
+    client = await createWorkerClient(containerName, { runtime });
+    clientCache.set(cacheKey, client);
   }
   return client;
 }
 
-export async function discoverSessionsViaWorker(containerName: string): Promise<RawSession[]> {
-  const client = await getWorkerClient(containerName);
+export async function discoverSessionsViaWorker(
+  containerName: string,
+  runtime?: 'docker' | 'podman'
+): Promise<RawSession[]> {
+  const client = await getWorkerClient(containerName, runtime);
   const sessions = await client.listSessions();
 
   return sessions.map((s) => ({
@@ -29,9 +36,10 @@ export async function discoverSessionsViaWorker(containerName: string): Promise<
 
 export async function getSessionDetailsViaWorker(
   containerName: string,
-  rawSession: RawSession
+  rawSession: RawSession,
+  runtime?: 'docker' | 'podman'
 ): Promise<SessionListItem | null> {
-  const client = await getWorkerClient(containerName);
+  const client = await getWorkerClient(containerName, runtime);
   const session = await client.getSession(rawSession.id);
 
   if (!session) {
@@ -51,9 +59,10 @@ export async function getSessionDetailsViaWorker(
 
 export async function getSessionMessagesViaWorker(
   containerName: string,
-  sessionId: string
+  sessionId: string,
+  runtime?: 'docker' | 'podman'
 ): Promise<{ id: string; messages: SessionMessage[] } | null> {
-  const client = await getWorkerClient(containerName);
+  const client = await getWorkerClient(containerName, runtime);
   const result = await client.getMessages(sessionId, { limit: 1000, offset: 0 });
 
   if (!result || result.messages.length === 0) {
@@ -74,9 +83,10 @@ export async function getSessionMessagesViaWorker(
 
 export async function deleteSessionViaWorker(
   containerName: string,
-  sessionId: string
+  sessionId: string,
+  runtime?: 'docker' | 'podman'
 ): Promise<{ success: boolean; error?: string }> {
-  const client = await getWorkerClient(containerName);
+  const client = await getWorkerClient(containerName, runtime);
   return client.deleteSession(sessionId);
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -109,6 +109,7 @@ export interface McpServerDefinition {
 export interface AgentConfig {
   port: number;
   host?: string;
+  runtime?: 'docker' | 'podman';
   credentials: WorkspaceCredentials;
   scripts: WorkspaceScripts;
   agents?: CodingAgents;

--- a/src/worker/client.ts
+++ b/src/worker/client.ts
@@ -43,12 +43,42 @@ async function fetchWithTimeout(
   }
 }
 
-async function isWorkerRunning(ip: string): Promise<boolean> {
+async function execFetch(
+  containerName: string,
+  path: string,
+  options?: { method?: string; timeout?: number }
+): Promise<{ ok: boolean; status: number; json(): Promise<any>; text(): Promise<string> }> {
+  const method = options?.method || 'GET';
+  const url = `http://localhost:${WORKER_PORT}${path}`;
+  const curlArgs = ['-s', '-w', '\\n%{http_code}', '-X', method, url];
+  const result = await execInContainer(containerName, ['curl', ...curlArgs], { user: 'workspace' });
+
+  const lines = result.stdout.trim().split('\n');
+  const statusCode = parseInt(lines.pop() || '0', 10);
+  const body = lines.join('\n');
+
+  return {
+    ok: statusCode >= 200 && statusCode < 300,
+    status: statusCode,
+    json: async () => JSON.parse(body),
+    text: async () => body,
+  };
+}
+
+async function isWorkerRunning(
+  ipOrContainer: string,
+  runtime?: 'docker' | 'podman'
+): Promise<boolean> {
   try {
-    const response = await fetchWithTimeout(`http://${ip}:${WORKER_PORT}/health`, {
-      timeout: HEALTH_TIMEOUT,
-    });
-    return response.ok;
+    if (runtime === 'podman') {
+      const response = await execFetch(ipOrContainer, '/health', { timeout: HEALTH_TIMEOUT });
+      return response.ok;
+    } else {
+      const response = await fetchWithTimeout(`http://${ipOrContainer}:${WORKER_PORT}/health`, {
+        timeout: HEALTH_TIMEOUT,
+      });
+      return response.ok;
+    }
   } catch {
     return false;
   }
@@ -66,86 +96,168 @@ async function startWorkerInContainer(containerName: string): Promise<void> {
   );
 }
 
-async function ensureWorkerRunning(containerName: string): Promise<string> {
-  const ip = await getContainerIp(containerName);
-  if (!ip) {
-    throw new Error(`Could not get IP for container: ${containerName}`);
-  }
+async function ensureWorkerRunning(
+  containerName: string,
+  runtime?: 'docker' | 'podman'
+): Promise<string> {
+  if (runtime === 'podman') {
+    if (await isWorkerRunning(containerName, runtime)) {
+      return containerName;
+    }
 
-  if (await isWorkerRunning(ip)) {
-    return ip;
-  }
+    await startWorkerInContainer(containerName);
 
-  await startWorkerInContainer(containerName);
+    const deadline = Date.now() + STARTUP_TIMEOUT;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, STARTUP_POLL_INTERVAL));
+      if (await isWorkerRunning(containerName, runtime)) {
+        return containerName;
+      }
+    }
 
-  const deadline = Date.now() + STARTUP_TIMEOUT;
-  while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, STARTUP_POLL_INTERVAL));
+    throw new Error(`Worker failed to start in container: ${containerName}`);
+  } else {
+    const ip = await getContainerIp(containerName);
+    if (!ip) {
+      throw new Error(`Could not get IP for container: ${containerName}`);
+    }
+
     if (await isWorkerRunning(ip)) {
       return ip;
     }
-  }
 
-  throw new Error(`Worker failed to start in container: ${containerName}`);
+    await startWorkerInContainer(containerName);
+
+    const deadline = Date.now() + STARTUP_TIMEOUT;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, STARTUP_POLL_INTERVAL));
+      if (await isWorkerRunning(ip)) {
+        return ip;
+      }
+    }
+
+    throw new Error(`Worker failed to start in container: ${containerName}`);
+  }
 }
 
-export async function createWorkerClient(containerName: string): Promise<WorkerClient> {
-  const ip = await ensureWorkerRunning(containerName);
-  const baseUrl = `http://${ip}:${WORKER_PORT}`;
+export async function createWorkerClient(
+  containerName: string,
+  options?: { runtime?: 'docker' | 'podman' }
+): Promise<WorkerClient> {
+  const runtime = options?.runtime;
+  const ipOrContainer = await ensureWorkerRunning(containerName, runtime);
 
-  return {
-    async health(): Promise<WorkerHealth> {
-      const response = await fetchWithTimeout(`${baseUrl}/health`);
-      if (!response.ok) {
-        throw new Error(`Failed to get health: ${response.statusText}`);
-      }
-      return response.json();
-    },
+  if (runtime === 'podman') {
+    return {
+      async health(): Promise<WorkerHealth> {
+        const response = await execFetch(containerName, '/health');
+        if (!response.ok) {
+          throw new Error(`Failed to get health: ${response.status}`);
+        }
+        return response.json();
+      },
 
-    async listSessions(): Promise<IndexedSession[]> {
-      const response = await fetchWithTimeout(`${baseUrl}/sessions`);
-      if (!response.ok) {
-        throw new Error(`Failed to list sessions: ${response.statusText}`);
-      }
-      const data = await response.json();
-      return data.sessions;
-    },
+      async listSessions(): Promise<IndexedSession[]> {
+        const response = await execFetch(containerName, '/sessions');
+        if (!response.ok) {
+          throw new Error(`Failed to list sessions: ${response.status}`);
+        }
+        const data = await response.json();
+        return data.sessions;
+      },
 
-    async getSession(id: string): Promise<IndexedSession | null> {
-      const response = await fetchWithTimeout(`${baseUrl}/sessions/${encodeURIComponent(id)}`);
-      if (response.status === 404) {
-        return null;
-      }
-      if (!response.ok) {
-        throw new Error(`Failed to get session: ${response.statusText}`);
-      }
-      const data = await response.json();
-      return data.session;
-    },
+      async getSession(id: string): Promise<IndexedSession | null> {
+        const response = await execFetch(containerName, `/sessions/${encodeURIComponent(id)}`);
+        if (response.status === 404) {
+          return null;
+        }
+        if (!response.ok) {
+          throw new Error(`Failed to get session: ${response.status}`);
+        }
+        const data = await response.json();
+        return data.session;
+      },
 
-    async getMessages(
-      id: string,
-      opts: { limit?: number; offset?: number } = {}
-    ): Promise<{ id: string; messages: Message[]; total: number }> {
-      const params = new URLSearchParams();
-      if (opts.limit !== undefined) params.set('limit', String(opts.limit));
-      if (opts.offset !== undefined) params.set('offset', String(opts.offset));
+      async getMessages(
+        id: string,
+        opts: { limit?: number; offset?: number } = {}
+      ): Promise<{ id: string; messages: Message[]; total: number }> {
+        const params = new URLSearchParams();
+        if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+        if (opts.offset !== undefined) params.set('offset', String(opts.offset));
 
-      const url = `${baseUrl}/sessions/${encodeURIComponent(id)}/messages?${params}`;
-      const response = await fetchWithTimeout(url);
-      if (!response.ok) {
-        throw new Error(`Failed to get messages: ${response.statusText}`);
-      }
-      return response.json();
-    },
+        const path = `/sessions/${encodeURIComponent(id)}/messages?${params}`;
+        const response = await execFetch(containerName, path);
+        if (!response.ok) {
+          throw new Error(`Failed to get messages: ${response.status}`);
+        }
+        return response.json();
+      },
 
-    async deleteSession(id: string): Promise<{ success: boolean; error?: string }> {
-      const response = await fetchWithTimeout(`${baseUrl}/sessions/${encodeURIComponent(id)}`, {
-        method: 'DELETE',
-      });
-      return response.json();
-    },
-  };
+      async deleteSession(id: string): Promise<{ success: boolean; error?: string }> {
+        const response = await execFetch(containerName, `/sessions/${encodeURIComponent(id)}`, {
+          method: 'DELETE',
+        });
+        return response.json();
+      },
+    };
+  } else {
+    const baseUrl = `http://${ipOrContainer}:${WORKER_PORT}`;
+
+    return {
+      async health(): Promise<WorkerHealth> {
+        const response = await fetchWithTimeout(`${baseUrl}/health`);
+        if (!response.ok) {
+          throw new Error(`Failed to get health: ${response.statusText}`);
+        }
+        return response.json();
+      },
+
+      async listSessions(): Promise<IndexedSession[]> {
+        const response = await fetchWithTimeout(`${baseUrl}/sessions`);
+        if (!response.ok) {
+          throw new Error(`Failed to list sessions: ${response.statusText}`);
+        }
+        const data = await response.json();
+        return data.sessions;
+      },
+
+      async getSession(id: string): Promise<IndexedSession | null> {
+        const response = await fetchWithTimeout(`${baseUrl}/sessions/${encodeURIComponent(id)}`);
+        if (response.status === 404) {
+          return null;
+        }
+        if (!response.ok) {
+          throw new Error(`Failed to get session: ${response.statusText}`);
+        }
+        const data = await response.json();
+        return data.session;
+      },
+
+      async getMessages(
+        id: string,
+        opts: { limit?: number; offset?: number } = {}
+      ): Promise<{ id: string; messages: Message[]; total: number }> {
+        const params = new URLSearchParams();
+        if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+        if (opts.offset !== undefined) params.set('offset', String(opts.offset));
+
+        const url = `${baseUrl}/sessions/${encodeURIComponent(id)}/messages?${params}`;
+        const response = await fetchWithTimeout(url);
+        if (!response.ok) {
+          throw new Error(`Failed to get messages: ${response.statusText}`);
+        }
+        return response.json();
+      },
+
+      async deleteSession(id: string): Promise<{ success: boolean; error?: string }> {
+        const response = await fetchWithTimeout(`${baseUrl}/sessions/${encodeURIComponent(id)}`, {
+          method: 'DELETE',
+        });
+        return response.json();
+      },
+    };
+  }
 }
 
 export { WORKER_PORT };

--- a/src/worker/client.ts
+++ b/src/worker/client.ts
@@ -50,7 +50,11 @@ async function execFetch(
 ): Promise<{ ok: boolean; status: number; json(): Promise<any>; text(): Promise<string> }> {
   const method = options?.method || 'GET';
   const url = `http://localhost:${WORKER_PORT}${path}`;
-  const curlArgs = ['-s', '-w', '\\n%{http_code}', '-X', method, url];
+  const curlArgs = ['-s', '-w', '\\n%{http_code}', '-X', method];
+  if (options?.timeout) {
+    curlArgs.push('--max-time', String(Math.ceil(options.timeout / 1000)));
+  }
+  curlArgs.push(url);
   const result = await execInContainer(containerName, ['curl', ...curlArgs], { user: 'workspace' });
 
   const lines = result.stdout.trim().split('\n');

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -493,13 +493,7 @@ export class WorkspaceManager {
     options: { strictWorker: boolean }
   ): Promise<void> {
     const WORKER_PORT = 7392;
-    const ip = await docker.getContainerIp(containerName);
-    if (!ip) {
-      console.warn(
-        `[sync] Could not get container IP for ${containerName}, skipping worker server`
-      );
-      return;
-    }
+    const isPodman = this.config.runtime === 'podman';
 
     const desiredVersion = pkg.version;
 
@@ -510,21 +504,58 @@ export class WorkspaceManager {
         })
       ).exitCode === 0;
 
-    try {
-      const healthResponse = await fetch(`http://${ip}:${WORKER_PORT}/health`, {
-        signal: AbortSignal.timeout(1000),
-      });
+    const checkHealth = async (): Promise<{ ok: boolean; version?: string }> => {
+      if (isPodman) {
+        try {
+          const result = await docker.execInContainer(
+            containerName,
+            ['curl', '-s', '-w', '\\n%{http_code}', `http://localhost:${WORKER_PORT}/health`],
+            { user: 'workspace' }
+          );
+          const lines = result.stdout.trim().split('\n');
+          const statusCode = parseInt(lines.pop() || '0', 10);
+          const body = lines.join('\n');
+          if (statusCode >= 200 && statusCode < 300) {
+            const health = JSON.parse(body);
+            return { ok: true, version: health.version };
+          }
+          return { ok: false };
+        } catch {
+          return { ok: false };
+        }
+      } else {
+        const ip = await docker.getContainerIp(containerName);
+        if (!ip) {
+          console.warn(
+            `[sync] Could not get container IP for ${containerName}, skipping worker server`
+          );
+          return { ok: false };
+        }
+        try {
+          const healthResponse = await fetch(`http://${ip}:${WORKER_PORT}/health`, {
+            signal: AbortSignal.timeout(1000),
+          });
+          if (healthResponse.ok) {
+            const health = (await healthResponse.json().catch(() => null)) as {
+              version?: string;
+            } | null;
+            return { ok: true, version: health?.version };
+          }
+          return { ok: false };
+        } catch {
+          return { ok: false };
+        }
+      }
+    };
 
-      if (healthResponse.ok) {
+    try {
+      const health = await checkHealth();
+      if (health.ok) {
         if (!hasSyncedPerry) {
           return;
         }
 
-        const health = (await healthResponse.json().catch(() => null)) as {
-          version?: string;
-        } | null;
-
-        if (health?.version === desiredVersion) {
+        if (health.version === desiredVersion) {
           return;
         }
 
@@ -552,11 +583,8 @@ export class WorkspaceManager {
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 200));
       try {
-        const response = await fetch(`http://${ip}:${WORKER_PORT}/health`, {
-          signal: AbortSignal.timeout(500),
-        });
-
-        if (!response.ok) {
+        const health = await checkHealth();
+        if (!health.ok) {
           continue;
         }
 
@@ -564,8 +592,7 @@ export class WorkspaceManager {
           return;
         }
 
-        const health = (await response.json().catch(() => null)) as { version?: string } | null;
-        if (health?.version === desiredVersion) {
+        if (health.version === desiredVersion) {
           return;
         }
       } catch {
@@ -931,6 +958,12 @@ export class WorkspaceManager {
       }
 
       const isPodman = this.config.runtime === 'podman';
+
+      // For podman runtime, pass DOCKER_HOST so entrypoint skips local dockerd
+      if (isPodman && process.env.DOCKER_HOST) {
+        containerEnv.DOCKER_HOST = process.env.DOCKER_HOST;
+      }
+
       const dockerVolumeName = `${VOLUME_PREFIX}${name}-docker`;
 
       // Only create Docker-in-Docker volume for docker runtime
@@ -948,7 +981,7 @@ export class WorkspaceManager {
       const containerId = await docker.createContainer({
         name: containerName,
         image: workspaceImage,
-        hostname: name,
+        hostname: isPodman ? undefined : name, // Skip hostname for podman (UTS namespace conflict)
         privileged: !isPodman, // Skip privileged mode for podman
         restartPolicy: 'unless-stopped',
         env: containerEnv,
@@ -1078,6 +1111,12 @@ export class WorkspaceManager {
         }
 
         const isPodman = this.config.runtime === 'podman';
+
+        // For podman runtime, pass DOCKER_HOST so entrypoint skips local dockerd
+        if (isPodman && process.env.DOCKER_HOST) {
+          containerEnv.DOCKER_HOST = process.env.DOCKER_HOST;
+        }
+
         const dockerVolumeName = `${VOLUME_PREFIX}${name}-docker`;
 
         // Only create Docker-in-Docker volume for docker runtime
@@ -1095,7 +1134,7 @@ export class WorkspaceManager {
         const containerId = await docker.createContainer({
           name: containerName,
           image: workspaceImage,
-          hostname: name,
+          hostname: isPodman ? undefined : name, // Skip hostname for podman (UTS namespace conflict)
           privileged: !isPodman, // Skip privileged mode for podman
           restartPolicy: 'unless-stopped',
           env: containerEnv,
@@ -1360,6 +1399,12 @@ export class WorkspaceManager {
       }
 
       const isPodman = this.config.runtime === 'podman';
+
+      // For podman runtime, pass DOCKER_HOST so entrypoint skips local dockerd
+      if (isPodman && process.env.DOCKER_HOST) {
+        containerEnv.DOCKER_HOST = process.env.DOCKER_HOST;
+      }
+
       const volumes = [{ source: cloneVolumeName, target: '/home/workspace', readonly: false }];
 
       // Only add Docker-in-Docker volume for docker runtime
@@ -1370,7 +1415,7 @@ export class WorkspaceManager {
       const containerId = await docker.createContainer({
         name: cloneContainerName,
         image: workspaceImage,
-        hostname: cloneName,
+        hostname: isPodman ? undefined : cloneName, // Skip hostname for podman (UTS namespace conflict)
         privileged: !isPodman, // Skip privileged mode for podman
         restartPolicy: 'unless-stopped',
         env: containerEnv,

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -930,22 +930,29 @@ export class WorkspaceManager {
         containerEnv.TS_AUTHKEY = this.config.tailscale.authKey;
       }
 
+      const isPodman = this.config.runtime === 'podman';
       const dockerVolumeName = `${VOLUME_PREFIX}${name}-docker`;
-      if (!(await docker.volumeExists(dockerVolumeName))) {
+
+      // Only create Docker-in-Docker volume for docker runtime
+      if (!isPodman && !(await docker.volumeExists(dockerVolumeName))) {
         await docker.createVolume(dockerVolumeName);
+      }
+
+      const volumes = [{ source: volumeName, target: '/home/workspace', readonly: false }];
+
+      // Only add Docker-in-Docker volume for docker runtime
+      if (!isPodman) {
+        volumes.push({ source: dockerVolumeName, target: '/var/lib/docker', readonly: false });
       }
 
       const containerId = await docker.createContainer({
         name: containerName,
         image: workspaceImage,
         hostname: name,
-        privileged: true,
+        privileged: !isPodman, // Skip privileged mode for podman
         restartPolicy: 'unless-stopped',
         env: containerEnv,
-        volumes: [
-          { source: volumeName, target: '/home/workspace', readonly: false },
-          { source: dockerVolumeName, target: '/var/lib/docker', readonly: false },
-        ],
+        volumes,
         ports: [{ hostPort: sshPort, containerPort: 22, protocol: 'tcp' }],
         labels: {
           'workspace.name': name,
@@ -1070,22 +1077,29 @@ export class WorkspaceManager {
           containerEnv.TS_AUTHKEY = this.config.tailscale.authKey;
         }
 
+        const isPodman = this.config.runtime === 'podman';
         const dockerVolumeName = `${VOLUME_PREFIX}${name}-docker`;
-        if (!(await docker.volumeExists(dockerVolumeName))) {
+
+        // Only create Docker-in-Docker volume for docker runtime
+        if (!isPodman && !(await docker.volumeExists(dockerVolumeName))) {
           await docker.createVolume(dockerVolumeName);
+        }
+
+        const volumes = [{ source: volumeName, target: '/home/workspace', readonly: false }];
+
+        // Only add Docker-in-Docker volume for docker runtime
+        if (!isPodman) {
+          volumes.push({ source: dockerVolumeName, target: '/var/lib/docker', readonly: false });
         }
 
         const containerId = await docker.createContainer({
           name: containerName,
           image: workspaceImage,
           hostname: name,
-          privileged: true,
+          privileged: !isPodman, // Skip privileged mode for podman
           restartPolicy: 'unless-stopped',
           env: containerEnv,
-          volumes: [
-            { source: volumeName, target: '/home/workspace', readonly: false },
-            { source: dockerVolumeName, target: '/var/lib/docker', readonly: false },
-          ],
+          volumes,
           ports: [{ hostPort: sshPort, containerPort: 22, protocol: 'tcp' }],
           labels: {
             'workspace.name': name,
@@ -1345,17 +1359,22 @@ export class WorkspaceManager {
         containerEnv.TS_AUTHKEY = this.config.tailscale.authKey;
       }
 
+      const isPodman = this.config.runtime === 'podman';
+      const volumes = [{ source: cloneVolumeName, target: '/home/workspace', readonly: false }];
+
+      // Only add Docker-in-Docker volume for docker runtime
+      if (!isPodman) {
+        volumes.push({ source: cloneDockerVolume, target: '/var/lib/docker', readonly: false });
+      }
+
       const containerId = await docker.createContainer({
         name: cloneContainerName,
         image: workspaceImage,
         hostname: cloneName,
-        privileged: true,
+        privileged: !isPodman, // Skip privileged mode for podman
         restartPolicy: 'unless-stopped',
         env: containerEnv,
-        volumes: [
-          { source: cloneVolumeName, target: '/home/workspace', readonly: false },
-          { source: cloneDockerVolume, target: '/var/lib/docker', readonly: false },
-        ],
+        volumes,
         ports: [{ hostPort: sshPort, containerPort: 22, protocol: 'tcp' }],
         labels: {
           'workspace.name': cloneName,

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -405,6 +405,14 @@ export class WorkspaceManager {
   }
 
   private async copyPerryWorker(containerName: string): Promise<void> {
+    if (this.config.runtime === 'podman') {
+      // Compiled binaries use host glibc linker paths (e.g. /nix/store/...)
+      // that don't exist in the Ubuntu workspace container. Copy JS dist
+      // and use bun (already installed in the image) as runtime instead.
+      await this.copyPerryWorkerJs(containerName);
+      return;
+    }
+
     const installedPath = path.join(os.homedir(), '.perry', 'bin', 'perry');
     const cwdDistPath = path.join(process.cwd(), 'dist', 'perry-worker');
     const distDir = path.dirname(new URL(import.meta.url).pathname);
@@ -450,6 +458,86 @@ export class WorkspaceManager {
     await docker.execInContainer(containerName, ['chmod', '755', destPath], {
       user: 'root',
     });
+  }
+
+  /**
+   * Podman-specific worker sync: copy JS dist directory + bun wrapper
+   * instead of a compiled binary that may have incompatible linker paths.
+   */
+  private async copyPerryWorkerJs(containerName: string): Promise<void> {
+    // Find dist directory containing index.js
+    const cwdDistDir = path.join(process.cwd(), 'dist');
+    const metaDistDir = path.dirname(new URL(import.meta.url).pathname);
+
+    let sourceDistDir: string | null = null;
+    for (const candidate of [cwdDistDir, metaDistDir]) {
+      try {
+        await fs.access(path.join(candidate, 'index.js'));
+        sourceDistDir = candidate;
+        break;
+      } catch {
+        // Try next
+      }
+    }
+
+    if (!sourceDistDir) {
+      console.warn('[sync] JS dist directory not found, session discovery may not work');
+      return;
+    }
+
+    // Find package.json (needed by bun for module resolution)
+    const cwdPkgJson = path.join(process.cwd(), 'package.json');
+    const parentPkgJson = path.join(sourceDistDir, '..', 'package.json');
+    let packageJsonPath: string | null = null;
+    for (const candidate of [cwdPkgJson, parentPkgJson]) {
+      try {
+        await fs.access(candidate);
+        packageJsonPath = candidate;
+        break;
+      } catch {
+        // Try next
+      }
+    }
+
+    try {
+      // Create destination and copy dist directory
+      await docker.execInContainer(containerName, ['mkdir', '-p', '/opt/perry'], { user: 'root' });
+      await docker.copyToContainer(containerName, sourceDistDir, '/opt/perry/dist', {
+        timeoutMs: 60_000,
+      });
+
+      // Copy package.json if found
+      if (packageJsonPath) {
+        await docker.copyToContainer(containerName, packageJsonPath, '/opt/perry/package.json', {
+          timeoutMs: 10_000,
+        });
+      }
+
+      // Create bun wrapper at /usr/local/bin/perry
+      await docker.execInContainer(
+        containerName,
+        [
+          'sh',
+          '-c',
+          'printf \'#!/bin/sh\\nexec bun /opt/perry/dist/index.js "$@"\\n\' > /usr/local/bin/perry && chmod +x /usr/local/bin/perry',
+        ],
+        { user: 'root' }
+      );
+
+      // Symlink for workspace user PATH
+      await docker.execInContainer(
+        containerName,
+        [
+          'sh',
+          '-c',
+          'mkdir -p /home/workspace/.local/bin && ln -sf /usr/local/bin/perry /home/workspace/.local/bin/perry',
+        ],
+        { user: 'root' }
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`[sync] Failed to copy JS dist to ${containerName}: ${message}`);
+    }
   }
 
   private async ensurePerryOnPath(containerName: string): Promise<void> {

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -597,7 +597,15 @@ export class WorkspaceManager {
         try {
           const result = await docker.execInContainer(
             containerName,
-            ['curl', '-s', '-w', '\\n%{http_code}', `http://localhost:${WORKER_PORT}/health`],
+            [
+              'curl',
+              '-s',
+              '--max-time',
+              '1',
+              '-w',
+              '\\n%{http_code}',
+              `http://localhost:${WORKER_PORT}/health`,
+            ],
             { user: 'workspace' }
           );
           const lines = result.stdout.trim().split('\n');


### PR DESCRIPTION
## Rootless Podman Support

Adds support for running Perry with rootless Podman as an alternative to Docker. All changes are gated behind a `runtime: "podman"` config option — Docker behavior is completely unchanged.

### Problem

Perry assumes Docker-in-Docker (DinD) inside workspace containers and communicates with the worker server via container IP networking. In rootless Podman:
- Containers run unprivileged (no `--privileged` flag)
- Container IPs are in nested network namespaces, unreachable from the host
- Port publishing doesn't work without iptables
- There's no local dockerd to manage

### Changes

**Runtime config abstraction** (`src/config/loader.ts`, `src/shared/types.ts`)
- New `runtime: "docker" | "podman"` field in `AgentConfig`
- Defaults to `"docker"` for backwards compatibility

**Workspace creation** (`src/workspace/manager.ts`)
- Skip `--privileged` flag, `--hostname`, and DinD volume for podman
- Forward `DOCKER_HOST` env var to workspace containers
- Dynamic worker port allocation (7392-7500) for multiple simultaneous workspaces

**Worker client communication** (`src/worker/client.ts`)
- New `execFetch()` helper that routes HTTP through `docker exec curl` for podman
- `createWorkerClient()` accepts optional `{ runtime }` parameter
- Health checks, session discovery, and all API calls use the exec transport when runtime is podman
- Timeout enforcement via curl `--max-time` flag

**Worker binary sync** (`src/workspace/manager.ts`)
- For podman: copies JS dist directory + bun wrapper instead of compiled binary
- Compiled binaries may have host-specific linker paths (e.g. Nix glibc) incompatible with workspace containers
- Bun is already installed in the workspace image

**Session discovery** (`src/agent/router.ts`, `src/sessions/agents/`)
- Runtime threaded through `discoverAllSessions`, `getAgentSessionDetails`, `getSessionMessages`
- All session-related worker client calls pass the runtime option

**Workspace image** (`perry/internal/src/lib/services.ts`, `perry/internal/src/commands/entrypoint.ts`)
- Entrypoint skips dockerd startup when `DOCKER_HOST` is set
- `monitorServices()` skips dockerd health check with external engine
- `Dockerfile.base` supports `--build-arg RUNTIME=podman` to skip docker-ce installation

### Testing

Tested end-to-end with rootless Podman-in-Podman (sidecar container via `DOCKER_HOST=tcp://podman-in-podman:2375`):

- ✅ Perry agent starts, Web UI accessible
- ✅ Workspace creation without --privileged or DinD
- ✅ Entrypoint detects external engine, no dockerd restart loop
- ✅ Worker server starts and health checks pass via exec transport
- ✅ Sessions API returns data (no infinite spinner)
- ✅ Claude Code runs inside workspace with credentials
- ✅ TypeScript compiles clean, all lint/format checks pass

### Commits

1. `ca65df5` — feat: add Podman runtime support (core abstraction)
2. `bc82636` — refactor: add Podman support to worker client communication
3. `6020522` — fix: ensure runtime config defaults to 'docker' and respect DOCKER_HOST in entrypoint
4. `ceca2c1` — fix: copy JS dist + bun wrapper instead of compiled binary for podman
5. `b065eea` — fix: enforce timeout in execFetch via curl --max-time
6. `a4a82b8` — fix: add --max-time to health check curl in podman path

Closes #159
